### PR TITLE
Add an optional 'ZKMapListener' to ZooKeeperMap which fires as nodes are added, changed, or removed.

### DIFF
--- a/src/java/com/twitter/common/zookeeper/ZooKeeperMap.java
+++ b/src/java/com/twitter/common/zookeeper/ZooKeeperMap.java
@@ -66,6 +66,29 @@ import java.util.logging.Logger;
 public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
 
   /**
+   * An optional listener which can be supplied and triggered when entries in a ZooKeeperMap
+   * are changed or removed. For a ZooKeeperMap of type <V>, the listener will fire a "nodeChanged"
+   * event with the name of the ZNode that changed, and its resulting value as interpreted by the
+   * provided deserializer. Removal of child nodes triggers the "nodeRemoved" method indicating the
+   * name of the ZNode which is no longer present in the map.
+   */
+  public interface ZKMapListener<V> {
+    
+    /**
+     * Fired when a node is added to the ZooKeeperMap or changed.
+     * @param nodeName indicates the name of the ZNode that was added or changed.
+     * @param value is the new value of the node after passing through your supplied deserializer.
+    */
+    public void nodeChanged(String nodeName, V value);
+
+    /**
+     * Fired when a node is removed from the ZooKeeperMap.
+     * @param nodeName indicates the name of the ZNode that was removed from the ZooKeeperMap.
+    */
+    public void nodeRemoved(String nodeName);
+  }
+
+  /**
    * Default deserializer for the constructor if you want to simply store the zookeeper byte[] data
    * in this map.
    */
@@ -80,9 +103,35 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
   private final ConcurrentMap<String, V> localMap;
   private final BackoffHelper backoffHelper;
 
+  private final ZKMapListener<V> mapListener;
+
   // Whether it's safe to re-establish watches if our zookeeper session has expired.
   private final Object safeToRewatchLock;
   private volatile boolean safeToRewatch;
+
+  /**
+   * Returns an initialized ZooKeeperMap.  The given path must exist at the time of
+   * creation or a {@link KeeperException} will be thrown.
+   *
+   * @param zkClient a zookeeper client
+   * @param nodePath path to a node whose data will be watched
+   * @param deserializer a function that converts byte[] data from a zk node to this map's
+   *     value type V
+   * @param listener is a ZKMapListener which fires when values are added, changed, or removed.
+   *
+   * @throws InterruptedException if the underlying zookeeper server transaction is interrupted
+   * @throws KeeperException.NoNodeException if the given nodePath doesn't exist
+   * @throws KeeperException if the server signals an error
+   * @throws ZooKeeperConnectionException if there was a problem connecting to the zookeeper
+   *     cluster
+   */
+  public static <V> ZooKeeperMap<V> create(ZooKeeperClient zkClient, String nodePath,
+      Function<byte[], V> deserializer, ZKMapListener<V> listener) throws InterruptedException, KeeperException,
+      ZooKeeperConnectionException {
+    ZooKeeperMap<V> zkMap = new ZooKeeperMap<V>(zkClient, nodePath, deserializer, listener);
+    zkMap.init();
+    return zkMap;
+  }
 
   /**
    * Returns an initialized ZooKeeperMap.  The given path must exist at the time of
@@ -102,9 +151,47 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
   public static <V> ZooKeeperMap<V> create(ZooKeeperClient zkClient, String nodePath,
       Function<byte[], V> deserializer) throws InterruptedException, KeeperException,
       ZooKeeperConnectionException {
-    ZooKeeperMap<V> zkMap = new ZooKeeperMap<V>(zkClient, nodePath, deserializer);
-    zkMap.init();
-    return zkMap;
+    return ZooKeeperMap.create(zkClient, nodePath, deserializer, null);
+  }
+
+  /**
+   * Initializes a ZooKeeperMap.  The given path must exist at the time of object creation or
+   * a {@link KeeperException} will be thrown.
+   *
+   * Please note that this object will not track any remote zookeeper data until {@link #init()}
+   * is successfully called.  After construction and before that call, this {@link Map} will
+   * be empty.
+   *
+   * @param zkClient a zookeeper client
+   * @param nodePath top-level node path under which the map data lives
+   * @param deserializer a function that converts byte[] data from a zk node to this map's
+   *     value type V
+   * @param listener is a ZKMapListener which fires when values are added, changed, or removed.
+   *
+   * @throws InterruptedException if the underlying zookeeper server transaction is interrupted
+   * @throws KeeperException.NoNodeException if the given nodePath doesn't exist
+   * @throws KeeperException if the server signals an error
+   * @throws ZooKeeperConnectionException if there was a problem connecting to the zookeeper
+   *     cluster
+   */
+  @VisibleForTesting
+  ZooKeeperMap(ZooKeeperClient zkClient, String nodePath,
+      Function<byte[], V> deserializer, ZKMapListener<V> mapListener) throws InterruptedException, KeeperException,
+      ZooKeeperConnectionException {
+    super();
+    this.mapListener = mapListener;
+    this.zkClient = Preconditions.checkNotNull(zkClient);
+    this.nodePath = MorePreconditions.checkNotBlank(nodePath);
+    this.deserializer = Preconditions.checkNotNull(deserializer);
+
+    localMap = new ConcurrentHashMap<String, V>();
+    backoffHelper = new BackoffHelper();
+    safeToRewatchLock = new Object();
+    safeToRewatch = false;
+
+    if (zkClient.get().exists(nodePath, null) == null) {
+      throw new KeeperException.NoNodeException();
+    }
   }
 
   /**
@@ -126,24 +213,12 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
    * @throws ZooKeeperConnectionException if there was a problem connecting to the zookeeper
    *     cluster
    */
-  @VisibleForTesting
-  ZooKeeperMap(ZooKeeperClient zkClient, String nodePath,
-      Function<byte[], V> deserializer) throws InterruptedException, KeeperException,
-      ZooKeeperConnectionException {
-    super();
-    this.zkClient = Preconditions.checkNotNull(zkClient);
-    this.nodePath = MorePreconditions.checkNotBlank(nodePath);
-    this.deserializer = Preconditions.checkNotNull(deserializer);
-
-    localMap = new ConcurrentHashMap<String, V>();
-    backoffHelper = new BackoffHelper();
-    safeToRewatchLock = new Object();
-    safeToRewatch = false;
-
-    if (zkClient.get().exists(nodePath, null) == null) {
-      throw new KeeperException.NoNodeException();
-    }
-  }
+   @VisibleForTesting
+   ZooKeeperMap(ZooKeeperClient zkClient, String nodePath,
+       Function<byte[], V> deserializer) throws InterruptedException, KeeperException,
+       ZooKeeperConnectionException {
+     this(zkClient, nodePath, deserializer, null);
+   }
 
   /**
    * Initialize zookeeper tracking for this {@link Map}.  Once this call returns, this object
@@ -331,11 +406,13 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
   @VisibleForTesting
   void removeEntry(String key) {
     localMap.remove(key);
+    if (mapListener != null) mapListener.nodeRemoved(key);
   }
 
   @VisibleForTesting
   void putEntry(String key, V value) {
     localMap.put(key, value);
+    if (mapListener != null) mapListener.nodeChanged(key, value);
   }
 
   private void rewatchDataNodes() throws InterruptedException {


### PR DESCRIPTION
Hi John,

We talked a bit about the contribution process for proposing and implementing enhancements for the "commons" lib a few weeks ago. Thanks for your help with the pants build process.

I've attached a diff that adds an optional "ZKMapListener" to ZooKeeperMap which allows users to be notified as child ZNodes are added, modified, and removed. The change preserves existing compatibility and interfaces, with the addition of a new constructor which optionally accepts the change listener. When nodes are added or their data changed, it fires "mapListener.nodeChanged(key, value)." Similarly when removed, the listener fires "mapListener.nodeRemoved(key)."

We're in the process of phasing in a stripped-down and mavenized version of the ZooKeeperClient and ZooKeeperMap libs with this modification to power our cluster membership and distributed stream processing at Boundary. We've been using this in production for about a week and the client seems to be working well -- thanks for releasing it (previously, we'd used Twitter's scala-zookeeper-client but noticed some odd behavior). I've begun the process of integrating this version of the client into Ordasity, our clustering library for stateful stream processing on the JVM (http://github.com/boundary/ordasity). The change to ZooKeeperMap allows Ordasity to be notified as topology and workload in ZooKeeper change, triggering it to reconfigure itself appropriately.

Let me know if you'd be interested in merging this pull request or if you have questions / concerns about the implementation, code style, or comments.

Thanks,

– Scott
