### PR TITLE
Fix for two bugs.

### DIFF
--- a/src/python/twitter/pants/tasks/ivy_resolve.py
+++ b/src/python/twitter/pants/tasks/ivy_resolve.py
@@ -262,6 +262,7 @@ class IvyResolve(NailgunTask):
       '-settings', self._ivy_settings,
       '-cache', self._cachedir,
       '-ivy', ivyxml,
+      '-types', 'jar',
       '-cachepath', classpathfile,
       '-confs'
     ]


### PR DESCRIPTION
1. OS X Python 2.6.1 has a bug in which the zipfile module fails to
   correctly unzip jars.
2. Limit the classpath to jars, since in some circumstances it can
   contain pom files, which causes problems later.
