### PR TITLE
Make invalidation more rigorous

### DIFF
--- a/src/python/twitter/pants/tasks/java_compile.py
+++ b/src/python/twitter/pants/tasks/java_compile.py
@@ -108,6 +108,9 @@ class JavaCompile(NailgunTask):
 
     self._confs = context.config.getlist('java-compile', 'confs')
 
+  def invalidate_for(self):
+    return [self._flatten]
+
   def execute(self, targets):
     java_targets = filter(JavaCompile._is_java, reversed(InternalTarget.sort_targets(targets)))
     if java_targets:

--- a/src/python/twitter/pants/tasks/protobuf_gen.py
+++ b/src/python/twitter/pants/tasks/protobuf_gen.py
@@ -78,6 +78,9 @@ class ProtobufGen(CodeGen):
   def invalidate_for(self):
     return self.gen_langs
 
+  def invalidate_for_files(self):
+    return [self.protobuf_binary]
+
   def is_gentarget(self, target):
     return isinstance(target, JavaProtobufLibrary)
 

--- a/src/python/twitter/pants/tasks/scala_compile.py
+++ b/src/python/twitter/pants/tasks/scala_compile.py
@@ -106,6 +106,9 @@ class ScalaCompile(NailgunTask):
     self._depfile_dir = os.path.join(workdir, 'depfiles')
     self._deps = Dependencies(self._classes_dir)
 
+  def invalidate_for(self):
+    return [self._incremental, self._flatten]
+
   def execute(self, targets):
     scala_targets = filter(is_scala, reversed(InternalTarget.sort_targets(targets)))
     if scala_targets:

--- a/src/python/twitter/pants/tasks/thrift_gen.py
+++ b/src/python/twitter/pants/tasks/thrift_gen.py
@@ -87,6 +87,9 @@ class ThriftGen(CodeGen):
   def invalidate_for(self):
     return self.gen_langs
 
+  def invalidate_for_files(self):
+    return [self.thrift_binary]
+
   def is_gentarget(self, target):
     return isinstance(target, JavaThriftLibrary) or isinstance(target, PythonThriftLibrary)
 


### PR DESCRIPTION
Adds a helper to make it easy to invalidate on pre-build build tools. 

Makes codegen targets invalidate on the generator. 

Makes JavaCompile and ScalaCompile invalidate on certain flag settings.
