### PR TITLE
Fix pants invalidation bug.

### DIFF
--- a/src/python/twitter/pants/goal/context.py
+++ b/src/python/twitter/pants/goal/context.py
@@ -78,6 +78,13 @@ class Context(object):
       id.update(target.id)
     return id.hexdigest()
 
+  def maybe_readable_identify(self, targets):
+    if len(targets) == 1:
+      id = targets[0].id
+    else:
+      id = self.identify(targets)
+    return id
+
   def __str__(self):
     return 'Context(id:%s, state:%s, targets:%s)' % (self.id, self.state, self.targets())
 

--- a/src/python/twitter/pants/tasks/__init__.py
+++ b/src/python/twitter/pants/tasks/__init__.py
@@ -40,7 +40,6 @@ class Task(object):
 
     self._build_cache = context.config.get('tasks', 'build_cache')
     self._basedir = os.path.join(self._build_cache, self.__class__.__name__)
-    self._extradata = os.path.join(self._basedir, Task.EXTRA_DATA)
 
   def invalidate(self, all=False):
     safe_rmtree(self._build_cache if all else self._basedir)
@@ -195,10 +194,12 @@ class Task(object):
         check = check.add(sha.hexdigest())
 
     if check is not None:
-      with safe_open(self._extradata, 'w') as pickled:
+      extradata_id = self.context.maybe_readable_identify(targets) + '.extra.data'
+      extradata = os.path.join(self._basedir, extradata_id)
+      with safe_open(extradata, 'w') as pickled:
         pickle.dump(check, pickled)
 
-      cache_key = cache_manager.check_content(Task.EXTRA_DATA, [self._extradata])
+      cache_key = cache_manager.check_content(extradata_id, [extradata])
       if cache_key:
         self.context.log.debug('invalidating all targets for %s' % self.__class__.__name__)
         for target in targets:

--- a/src/python/twitter/pants/tasks/java_compile.py
+++ b/src/python/twitter/pants/tasks/java_compile.py
@@ -149,11 +149,7 @@ class JavaCompile(NailgunTask):
   def execute_single_compilation(self, java_targets, cp):
     self.context.log.info('Compiling targets %s' % str(java_targets))
 
-    # Compute the id of this compilation. We try to make it human-readable.
-    if len(java_targets) == 1:
-      compilation_id = java_targets[0].id
-    else:
-      compilation_id = self.context.identify(java_targets)
+    compilation_id = self.context.maybe_readable_identify(java_targets)
 
     if self._flatten:
       # If compiling in flat mode, we let all dependencies aggregate into a single well-known depfile. This

--- a/src/python/twitter/pants/tasks/scala_compile.py
+++ b/src/python/twitter/pants/tasks/scala_compile.py
@@ -156,11 +156,7 @@ class ScalaCompile(NailgunTask):
     """Execute a single compilation, updating upstream_analysis_caches if needed."""
     self.context.log.info('Compiling targets %s' % str(scala_targets))
 
-    # Compute the id of this compilation. We try to make it human-readable.
-    if len(scala_targets) == 1:
-      compilation_id = scala_targets[0].id
-    else:
-      compilation_id = self.context.identify(scala_targets)
+    compilation_id = self.context.maybe_readable_identify(scala_targets)
 
     if self._flatten:
       # If compiling in flat mode, we let all dependencies aggregate into a single well-known depfile. This


### PR DESCRIPTION
Extra invalidation data had a fixed key for all targets in a non-flat
build, so the invalidation only applied to the first target, which
updated the key and made it appear to be unchanged for the subsequent
targets.

This change prefixes the key with the id of the set of targets.
