### PR TITLE
Add a --jvm-run-only-print-cmd-line flag to pants.

### DIFF
--- a/src/python/twitter/pants/tasks/binary_utils.py
+++ b/src/python/twitter/pants/tasks/binary_utils.py
@@ -125,7 +125,7 @@ def safe_classpath(logger=None):
     yield
 
 
-def runjava(jvmargs=None, classpath=None, main=None, args=None):
+def runjava(jvmargs=None, classpath=None, main=None, args=None, only_print_cmd_line=False):
   """Spawns a java process with the supplied configuration and returns its exit code."""
   cmd = ['java']
   if jvmargs:
@@ -137,9 +137,13 @@ def runjava(jvmargs=None, classpath=None, main=None, args=None):
   if args:
     cmd.extend(args)
 
-  log.debug('Executing: %s' % ' '.join(cmd))
-  with safe_classpath():
-    return subprocess.call(cmd)
+  if only_print_cmd_line:
+    print(' '.join(cmd))
+    return 0
+  else:
+    log.debug('Executing: %s' % ' '.join(cmd))
+    with safe_classpath():
+      return subprocess.call(cmd)
 
 
 def nailgun_profile_classpath(nailgun_task, profile, ivy_jar=None, ivy_settings=None):

--- a/src/python/twitter/pants/tasks/jvm_run.py
+++ b/src/python/twitter/pants/tasks/jvm_run.py
@@ -41,6 +41,10 @@ class JvmRun(JvmTask):
       action="callback", callback=mkflag.set_bool, default=False,
       help = "[%default] Run binary with a debugger")
 
+    option_group.add_option(mkflag("only-print-cmd-line"), dest = "only_print_cmd_line",
+      action="store_true", default=False,
+      help = "[%default] Instead of running, just print the cmd line needed to run")
+
   def __init__(self, context):
     Task.__init__(self, context)
     self.jvm_args = context.config.getlist('jvm-run', 'jvm_args', default=[])
@@ -54,6 +58,7 @@ class JvmRun(JvmTask):
     if context.options.run_debug:
       self.jvm_args.extend(context.config.getlist('jvm', 'debug_args'))
     self.confs = context.config.getlist('jvm-run', 'confs')
+    self.only_print_cmd_line = context.options.only_print_cmd_line
 
   def execute(self, targets):
     # Run the first target that is a binary.
@@ -64,7 +69,8 @@ class JvmRun(JvmTask):
         jvmargs=self.jvm_args,
         classpath=(self.classpath(confs=self.confs)),
         main=main,
-        args=self.args
+        args=self.args,
+        only_print_cmd_line=self.only_print_cmd_line
       )
       if result != 0:
         raise TaskError()


### PR DESCRIPTION
This is useful when using pants in scripts etc. and since you can't
run multiple concurrent instances of pants.
