### PR TITLE
ZooKeeperClient: Add chroot support

### DIFF
--- a/src/java/com/twitter/common/zookeeper/ZooKeeperClient.java
+++ b/src/java/com/twitter/common/zookeeper/ZooKeeperClient.java
@@ -214,6 +214,19 @@ public class ZooKeeperClient {
 
   /**
    * Creates an unconnected client that will lazily attempt to connect on the first call to
+   * {@link #get}.
+   *
+   * @param sessionTimeout the ZK session timeout
+   * @param zooKeeperServers the set of servers forming the ZK cluster
+   * @param chroot the ZK chroot
+   */
+  public ZooKeeperClient(Amount<Integer, Time> sessionTimeout,
+      Iterable<InetSocketAddress> zooKeeperServers, String chroot) {
+    this(sessionTimeout, Credentials.NONE, zooKeeperServers, chroot);
+  }
+
+  /**
+   * Creates an unconnected client that will lazily attempt to connect on the first call to
    * {@link #get()}.  All successful connections will be authenticated with the given
    * {@code credentials}.
    *
@@ -238,17 +251,33 @@ public class ZooKeeperClient {
    */
   public ZooKeeperClient(Amount<Integer, Time> sessionTimeout, Credentials credentials,
       Iterable<InetSocketAddress> zooKeeperServers) {
+    this(sessionTimeoutMs, credentials, zooKeeperServers, "");
+  }
+
+  /**
+   * Creates an unconnected client that will lazily attempt to connect on the first call to
+   * {@link #get}.  All successful connections will be authenticated with the given
+   * {@code credentials}.
+   *
+   * @param sessionTimeout the ZK session timeout
+   * @param credentials the credentials to authenticate with
+   * @param zooKeeperServers the set of servers forming the ZK cluster
+   * @param chroot the ZK chroot
+   */
+  public ZooKeeperClient(Amount<Integer, Time> sessionTimeout, Credentials credentials,
+      Iterable<InetSocketAddress> zooKeeperServers, String chroot) {
     this.sessionTimeoutMs = Preconditions.checkNotNull(sessionTimeout).as(Time.MILLISECONDS);
     this.credentials = Preconditions.checkNotNull(credentials);
 
     Preconditions.checkNotNull(zooKeeperServers);
     Preconditions.checkArgument(!Iterables.isEmpty(zooKeeperServers),
         "Must present at least 1 ZK server");
+    Preconditions.checkNotNull(chroot);
 
     Iterable<String> servers =
         Iterables.transform(ImmutableSet.copyOf(zooKeeperServers),
             InetSocketAddressHelper.INET_TO_STR);
-    this.zooKeeperServers = Joiner.on(',').join(servers);
+    this.zooKeeperServers = Joiner.on(',').join(servers) + chroot;
   }
 
   /**


### PR DESCRIPTION
From #52.

Adds two constructors that take an extra `String chroot` argument, which must be non-null, and defaults to `""`. `chroot` is then appended on to the end of `this.zooKeeperServers`.

Apologies: I wasn't able to compile or run this. I fought with manually injecting some dependencies into ivy (javax.jms, com.sun.jdmk, and com.sun.jmx), but then I gave up after it failed to find thrift (`Do not have thrift binary for os: Mac OS X 10.8 x86_64`). But it's a pretty simple change.
