### PR TITLE
Release lock right before running a process. 

### DIFF
--- a/src/python/twitter/pants/tasks/jvm_run.py
+++ b/src/python/twitter/pants/tasks/jvm_run.py
@@ -63,6 +63,7 @@ class JvmRun(JvmTask):
 
   def execute(self, targets):
     # Run the first target that is a binary.
+    self.context.lock.release()
     binaries = filter(is_binary, targets)
     if len(binaries) > 0:  # We only run the first one.
       main = binaries[0].main


### PR DESCRIPTION
This is so we can run multiple processes concurrently, and/or
use other pants commands concurrently with a run command.
