### PR TITLE
Labels on pants targets.

### DIFF
--- a/src/python/twitter/pants/__init__.py
+++ b/src/python/twitter/pants/__init__.py
@@ -116,32 +116,22 @@ wiki = Wiki
 
 def has_sources(target):
   """Returns True if the target has sources."""
-
-  return isinstance(target, TargetWithSources)
+  return target.has_label('sources')
 
 
 def is_exported(target):
   """Returns True if the target provides an artifact exportable from the repo."""
-
-  return isinstance(target, ExportableJvmLibrary) and target.provides
+  return target.has_label('exportable')
 
 
 def is_internal(target):
   """Returns True if the target is internal to the repo (ie: it might have dependencies)."""
-
-  return isinstance(target, InternalTarget)
+  return target.has_label('internal')
 
 
 def is_jvm(target):
   """Returns True if the target produces jvm bytecode."""
-
-  return isinstance(target, JvmTarget)
-
-
-def is_apt(target):
-  """Returns True if the target produces annotation processors."""
-
-  return isinstance(target, AnnotationProcessor)
+  return target.has_label('jvm')
 
 
 def has_jvm_targets(targets):
@@ -165,65 +155,52 @@ def extract_jvm_targets(targets):
         yield real_target
 
 
+def is_codegen(target):
+  """Returns True if the target is a codegen target."""
+  return target.has_label('codegen')
+
 def is_doc(target):
   """Returns True if the target is a documentation target."""
-
-  return isinstance(target, Doc)
+  return target.has_label('doc')
 
 
 def is_jar_library(target):
   """Returns True if the target is an external jar library."""
-
-  return isinstance(target, JarLibrary)
+  return target.has_label('jars')
 
 
 def is_java(target):
   """Returns True if the target has or generates java sources."""
-
-  return isinstance(target, JavaLibrary) or (
-    isinstance(target, AnnotationProcessor)) or (
-    isinstance(target, JavaProtobufLibrary)) or (
-    isinstance(target, JavaTests)) or (
-    is_thrift(target))
-
-
-def is_thrift(target):
-  """Returns True if the target has thrift IDL sources."""
-
-  return isinstance(target, JavaThriftLibrary)
+  return target.has_label('java')
 
 
 def is_apt(target):
   """Returns True if the target exports an annotation processor."""
-
-  return isinstance(target, AnnotationProcessor)
+  return target.has_label('apt')
 
 
 def is_python(target):
   """Returns True if the target has python sources."""
-
-  return isinstance(target, PythonTarget)
+  return target.has_label('python')
 
 
 def is_scala(target):
   """Returns True if the target has scala sources."""
-
-  return isinstance(target, ScalaLibrary) or isinstance(target, ScalaTests)
+  return target.has_label('scala')
 
 
 def is_scalac_plugin(target):
-  return isinstance(target, ScalacPlugin)
+  """Returns True if the target builds a scalac plugin."""
+  return target.has_label('scalac_plugin')
 
 
 def is_test(t):
   """Returns True if the target is comprised of tests."""
-
-  return isinstance(t, JavaTests) or isinstance(t, ScalaTests) or isinstance(t, PythonTests)
+  return t.has_label('tests')
 
 
 def is_jar_dependency(dep):
   """Returns True if the dependency is an external jar."""
-
   return isinstance(dep, JarDependency)
 
 

--- a/src/python/twitter/pants/commands/goal.py
+++ b/src/python/twitter/pants/commands/goal.py
@@ -30,7 +30,7 @@ from twitter.common import log
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil import safe_mkdir, safe_rmtree
 from twitter.common.lang import Compatibility
-from twitter.pants import get_buildroot, goal, group, is_apt, is_scala
+from twitter.pants import get_buildroot, goal, group, is_apt, is_codegen, is_scala
 from twitter.pants.base import Address, BuildFile, Config, ParseContext, Target
 from twitter.pants.base.rcfile import RcFile
 from twitter.pants.commands import Command
@@ -508,7 +508,7 @@ goal(
 # Support straight up checkstyle runs in addition to checkstyle as last phase of compile below
 goal(name='javac',
      action=JavaCompile,
-     group=group('gen', lambda target: target.is_codegen),
+     group=group('gen', lambda target: is_codegen(target)),
      dependencies=['gen', 'resolve']).install('checkstyle')
 
 

--- a/src/python/twitter/pants/commands/ide.py
+++ b/src/python/twitter/pants/commands/ide.py
@@ -25,6 +25,7 @@ from twitter.pants import (
   get_buildroot,
   has_sources,
   is_apt,
+  is_codegen,
   is_java,
   is_scala,
   is_test
@@ -126,7 +127,7 @@ class Ide(Command):
 
     foil = list(all_targets)[0]
     def is_cp(target):
-      return target.is_codegen \
+      return is_codegen(target) \
              or is_apt(target) \
              or (skip_java and is_java(target)) \
              or (skip_scala and is_scala(target))
@@ -240,7 +241,7 @@ class Project(object):
 
     def source_target(target):
       return has_sources(target) \
-          and (not target.is_codegen
+          and (not is_codegen(target)
                and not (self.skip_java and is_java(target))
                and not (self.skip_scala and is_scala(target)))
 

--- a/src/python/twitter/pants/targets/annotation_processor.py
+++ b/src/python/twitter/pants/targets/annotation_processor.py
@@ -51,6 +51,8 @@ class AnnotationProcessor(ExportableJvmLibrary):
                                   (),
                                   is_meta)
 
+    self.add_label('java')
+    self.add_label('apt')
     self.resources = self._resolve_paths(ExportableJvmLibrary.RESOURCES_BASE_DIR, resources)
     self.processors = processors
 

--- a/src/python/twitter/pants/targets/doc.py
+++ b/src/python/twitter/pants/targets/doc.py
@@ -28,6 +28,7 @@ class Doc(InternalTarget, TargetWithSources):
     TargetWithSources.__init__(self, name)
     if not sources:
       raise TargetDefinitionException(self, 'No sources specified')
+    self.add_label('doc')
     self.name = name
     self.sources = self._resolve_paths(self.target_base, sources)
     self.resources = self._resolve_paths(self.target_base, resources) if resources else []

--- a/src/python/twitter/pants/targets/exportable_jvm_library.py
+++ b/src/python/twitter/pants/targets/exportable_jvm_library.py
@@ -35,6 +35,7 @@ class ExportableJvmLibrary(JvmTarget):
     self.provides = provides
 
     JvmTarget.__init__(self, name, sources, dependencies, excludes, buildflags, is_meta)
+    self.add_label('exportable')
 
   def _provides(self):
     return self.provides

--- a/src/python/twitter/pants/targets/internal.py
+++ b/src/python/twitter/pants/targets/internal.py
@@ -153,6 +153,7 @@ class InternalTarget(Target):
   def __init__(self, name, dependencies, is_meta):
     Target.__init__(self, name, is_meta)
 
+    self.add_label('internal')
     self.dependencies = OrderedSet()
     self.internal_dependencies = OrderedSet()
     self.jar_dependencies = OrderedSet()

--- a/src/python/twitter/pants/targets/jar_library.py
+++ b/src/python/twitter/pants/targets/jar_library.py
@@ -28,7 +28,7 @@ class JarLibrary(Target):
 
     assert len(dependencies) > 0, "At least one dependency must be specified"
     Target.__init__(self, name, False)
-
+    self.add_label('jars')
     self.dependencies = dependencies
 
   def resolve(self):

--- a/src/python/twitter/pants/targets/java_library.py
+++ b/src/python/twitter/pants/targets/java_library.py
@@ -54,6 +54,7 @@ class JavaLibrary(ExportableJvmLibrary):
                                   buildflags,
                                   is_meta)
 
+    self.add_label('java')
     self.sibling_resources_base = os.path.join(os.path.dirname(self.target_base), 'resources')
     self.resources = self._resolve_paths(self.sibling_resources_base, resources)
     self.deployjar = deployjar

--- a/src/python/twitter/pants/targets/java_protobuf_library.py
+++ b/src/python/twitter/pants/targets/java_protobuf_library.py
@@ -49,7 +49,8 @@ class JavaProtobufLibrary(ExportableJvmLibrary):
                                   excludes,
                                   buildflags,
                                   is_meta)
-    self.is_codegen = True
+    self.add_label('java')
+    self.add_label('codegen')
 
   def _as_jar_dependency(self):
     return ExportableJvmLibrary._as_jar_dependency(self).with_sources()

--- a/src/python/twitter/pants/targets/java_tests.py
+++ b/src/python/twitter/pants/targets/java_tests.py
@@ -40,6 +40,8 @@ class JavaTests(JvmTarget):
         for this target"""
 
     JvmTarget.__init__(self, name, sources, dependencies, excludes, buildflags, is_meta)
+    self.add_label('java')
+    self.add_label('tests')
 
   def _create_template_data(self):
     jar_dependency, id, exported = self._get_artifact_info()

--- a/src/python/twitter/pants/targets/java_thrift_library.py
+++ b/src/python/twitter/pants/targets/java_thrift_library.py
@@ -48,7 +48,8 @@ class JavaThriftLibrary(ExportableJvmLibrary):
                                   excludes,
                                   buildflags,
                                   is_meta)
-    self.is_codegen = True
+    self.add_label('java')
+    self.add_label('codegen')
 
   def _as_jar_dependency(self):
     return ExportableJvmLibrary._as_jar_dependency(self).with_sources()

--- a/src/python/twitter/pants/targets/java_thriftstore_dml_library.py
+++ b/src/python/twitter/pants/targets/java_thriftstore_dml_library.py
@@ -39,7 +39,7 @@ class JavaThriftstoreDMLLibrary(ExportableJvmLibrary):
                                   sources,
                                   provides = None,
                                   dependencies = dependencies)
-    self.is_codegen = True
+    self.add_label('codegen')
 
   def _as_jar_dependency(self):
     return ExportableJvmLibrary._as_jar_dependency(self).with_sources()

--- a/src/python/twitter/pants/targets/jvm_target.py
+++ b/src/python/twitter/pants/targets/jvm_target.py
@@ -16,7 +16,6 @@
 
 import os
 
-from twitter.pants.base import TargetDefinitionException
 from twitter.pants.targets.internal import InternalTarget
 from twitter.pants.targets.jar_dependency import JarDependency
 from twitter.pants.targets.with_sources import TargetWithSources
@@ -32,6 +31,7 @@ class JvmTarget(InternalTarget, TargetWithSources):
     InternalTarget.__init__(self, name, dependencies, is_meta)
     TargetWithSources.__init__(self, name, is_meta)
 
+    self.add_label('jvm')
     self.sources = self._resolve_paths(self.target_base, sources) or []
     self.excludes = excludes or []
     self.buildflags = buildflags or []

--- a/src/python/twitter/pants/targets/pants_target.py
+++ b/src/python/twitter/pants/targets/pants_target.py
@@ -32,8 +32,9 @@ class Pants(Target):
         return Address.parse(parse_context.buildfile.root_dir, spec, False)
 
     self.address = parse_address()
-
-    Target.__init__(self, self.address.target_name, False)
+    # We must disable the re-init check, because our funky __getattr__ breaks it.
+    # We're not involved in any multiple inheritance, so it's OK to disable it here.
+    Target.__init__(self, self.address.target_name, False, reinit_check=False)
 
   def register(self):
     # A pants target is a pointer, do not register it as an actual target (see resolve).

--- a/src/python/twitter/pants/targets/python_target.py
+++ b/src/python/twitter/pants/targets/python_target.py
@@ -22,6 +22,7 @@ class PythonTarget(TargetWithSources):
   def __init__(self, name, sources, resources=None, dependencies=None):
     TargetWithSources.__init__(self, name)
 
+    self.add_label('python')
     self.sources = self._resolve_paths(self.target_base, sources)
     self.resources = self._resolve_paths(self.target_base, resources) if resources else OrderedSet()
     self.dependencies = OrderedSet(dependencies) if dependencies else OrderedSet()

--- a/src/python/twitter/pants/targets/python_tests.py
+++ b/src/python/twitter/pants/targets/python_tests.py
@@ -30,6 +30,8 @@ class PythonTests(PythonTarget):
       soft_dependencies: Whether or not we should ignore dependency resolution
                          errors for this test.  [Default: False]
     """
+    self.add_label('python')
+    self.add_label('tests')
     self._timeout = timeout
     self._soft_dependencies = bool(soft_dependencies)
     PythonTarget.__init__(self, name, sources, resources, dependencies)

--- a/src/python/twitter/pants/targets/scala_library.py
+++ b/src/python/twitter/pants/targets/scala_library.py
@@ -58,6 +58,7 @@ class ScalaLibrary(ExportableJvmLibrary):
                                   buildflags,
                                   is_meta)
 
+    self.add_label('scala')
     self.java_sources = java_sources
 
     base_parent = os.path.dirname(self.target_base)

--- a/src/python/twitter/pants/targets/scala_tests.py
+++ b/src/python/twitter/pants/targets/scala_tests.py
@@ -48,6 +48,8 @@ class ScalaTests(JvmTarget):
                        excludes,
                        buildflags,
                        is_meta)
+    self.add_label('scala')
+    self.add_label('tests')
     self.java_sources = java_sources
 
   def _create_template_data(self):

--- a/src/python/twitter/pants/targets/scalac_plugin.py
+++ b/src/python/twitter/pants/targets/scalac_plugin.py
@@ -47,6 +47,6 @@ class ScalacPlugin(ScalaLibrary):
 
     ScalaLibrary.__init__(self, name, sources, java_sources, provides, dependencies, excludes,
                           resources)
-
+    self.add_label('scalac_plugin')
     self.plugin = plugin or name
     self.classname = classname

--- a/src/python/twitter/pants/targets/with_sources.py
+++ b/src/python/twitter/pants/targets/with_sources.py
@@ -26,6 +26,7 @@ class TargetWithSources(Target):
   def __init__(self, name, is_meta=False):
     Target.__init__(self, name, is_meta)
 
+    self.add_label('sources')
     self.target_base = SourceRoot.find(self)
 
   def expand_files(self, recursive=True, include_buildfile=True):

--- a/src/python/twitter/pants/tasks/checkstyle.py
+++ b/src/python/twitter/pants/tasks/checkstyle.py
@@ -20,7 +20,7 @@ import os
 
 from twitter.common import log
 from twitter.common.dirutil import safe_open
-from twitter.pants import is_java
+from twitter.pants import is_codegen, is_java
 from twitter.pants.tasks import TaskError
 from twitter.pants.tasks.binary_utils import nailgun_profile_classpath
 from twitter.pants.tasks.nailgun_task import NailgunTask
@@ -32,7 +32,7 @@ CHECKSTYLE_MAIN = 'com.puppycrawl.tools.checkstyle.Main'
 class Checkstyle(NailgunTask):
   @staticmethod
   def _is_checked(target):
-    return is_java(target) and not target.is_codegen
+    return is_java(target) and not is_codegen(target)
 
   @classmethod
   def setup_parser(cls, option_group, args, mkflag):

--- a/src/python/twitter/pants/tasks/ide_gen.py
+++ b/src/python/twitter/pants/tasks/ide_gen.py
@@ -23,6 +23,7 @@ from twitter.pants import (
   extract_jvm_targets,
   get_buildroot,
   has_sources,
+  is_codegen,
   is_java,
   is_scala,
   is_test,
@@ -161,7 +162,7 @@ class IdeGen(JvmBinaryTask):
     """
     def is_cp(target):
       return (
-        target.is_codegen
+        is_codegen(target)
 
         # Some IDEs need annotation processors pre-compiled, others are smart enough to detect and
         # proceed in 2 compile rounds
@@ -362,7 +363,7 @@ class Project(object):
 
     def source_target(target):
       return (self.transitive or target in self.targets) and has_sources(target) \
-          and (not target.is_codegen
+          and (not is_codegen(target)
                and not (self.skip_java and is_java(target))
                and not (self.skip_scala and is_scala(target)))
 

--- a/src/python/twitter/pants/tasks/junit_run.py
+++ b/src/python/twitter/pants/tasks/junit_run.py
@@ -22,7 +22,7 @@ import sys
 
 from twitter.common.dirutil import safe_mkdir, safe_open
 
-from twitter.pants import get_buildroot, is_java, is_scala, is_test
+from twitter.pants import is_codegen, is_java, is_scala, is_test
 from twitter.pants.tasks import binary_utils, Task, TaskError
 from twitter.pants.tasks.binary_utils import profile_classpath, runjava, safe_args
 from twitter.pants.tasks.jvm_task import JvmTask
@@ -260,7 +260,7 @@ class JUnitRun(JvmTask):
       classes_under_test = set()
       classes_by_source = self.context.products.get('classes')
       def add_sources_under_test(tgt):
-        if is_java(tgt) and not is_test(tgt) and not tgt.is_codegen:
+        if is_java(tgt) and not is_test(tgt) and not is_codegen(tgt):
           for source in tgt.sources:
             classes = classes_by_source.get(source)
             if classes:

--- a/src/python/twitter/pants/tasks/protobuf_gen.py
+++ b/src/python/twitter/pants/tasks/protobuf_gen.py
@@ -148,7 +148,7 @@ class ProtobufGen(CodeGen):
                                       sources=genfiles,
                                       dependencies=self.javadeps)
     tgt.id = target.id
-    tgt.is_codegen = True
+    tgt.add_label('codegen')
     for dependee in dependees:
       dependee.update_dependencies([tgt])
     return tgt

--- a/src/python/twitter/pants/tasks/thrift_gen.py
+++ b/src/python/twitter/pants/tasks/thrift_gen.py
@@ -175,7 +175,7 @@ class ThriftGen(CodeGen):
                                       sources=genfiles,
                                       dependencies=self.gen_java.deps)
     tgt.id = target.id
-    tgt.is_codegen = True
+    tgt.add_label('codegen')
     for dependee in dependees:
       dependee.update_dependencies([tgt])
     return tgt

--- a/src/python/twitter/pants/tasks/thriftstore_dml_gen.py
+++ b/src/python/twitter/pants/tasks/thriftstore_dml_gen.py
@@ -66,7 +66,7 @@ class ThriftstoreDMLGen(CodeGen):
                                                    sources=[],
                                                    dependencies=self.javadeps)
         java_dml_lib.id = dml_lib_target.id
-        java_dml_lib.is_codegen = True
+        java_dml_lib.add_label('codegen')
         java_dml_lib.update_dependencies([thrift_dml_lib])
         self.gen_dml_jls[dml_lib_target] = java_dml_lib
 

--- a/tests/python/twitter/pants/ant/test-ide.py
+++ b/tests/python/twitter/pants/ant/test-ide.py
@@ -17,6 +17,7 @@
 __author__ = 'John Sirios'
 
 from twitter.common.collections import OrderedSet
+from twitter.pants import is_codegen
 from twitter.pants.ant.ide import _extract_target
 
 import unittest
@@ -37,14 +38,15 @@ class MockTarget(object):
     self.excludes = []
     self.rev = rev
 
-
   def __repr__(self):
     return self.name
-
 
   def walk(self, func, unused_predicate):
     if not self.rev:
       func(self)
+
+  def has_label(self, name):
+    return name == 'codegen' and self.is_codegen
 
 
 # TODO(John Sirois): test --no-{java,scala} behavior
@@ -95,7 +97,7 @@ class IdeTest(unittest.TestCase):
 
     internal_deps, jar_deps = _extract_target(
       [a, e, j],
-      lambda target: target.is_apt or target.is_codegen
+      lambda target: target.is_apt or is_codegen(target)
     )
 
     self.assertEquals(OrderedSet([c, b]), internal_deps,


### PR DESCRIPTION
This allows 3rd party custom targets to be treated
uniformly with standard targets for things like being
considered 'is_scala' or 'is_codegen' etc.
