### PR TITLE
No need to copy classfiles around in ScalaCompile.

### DIFF
--- a/src/python/twitter/pants/tasks/jar_create.py
+++ b/src/python/twitter/pants/tasks/jar_create.py
@@ -84,7 +84,7 @@ class JarCreate(Task):
     self.confs = context.config.getlist('jar-create', 'confs')
     self.compression = ZIP_DEFLATED if options.jar_create_compressed else ZIP_STORED
 
-    self.jar_classes = options.jar_create_classes or products.isrequired('jars')
+    self.jar_classes = products.isrequired('jars') or options.jar_create_classes
     if self.jar_classes:
       products.require('classes')
 


### PR DESCRIPTION
The genfile mechanism already handles multiple output dirs perfectly fine.
So all this does is handle the classpath correctly. That copying can add
minutes to a large build, and again when cleaning the extra files.

Also fixes a tiny nit in jar_create, for consistency with subsequent lines.
