### PR TITLE
Allow annotations on thrift typedefs.

### DIFF
--- a/src/antlr/twitter/thrift/descriptors/AntlrThrift.g
+++ b/src/antlr/twitter/thrift/descriptors/AntlrThrift.g
@@ -100,10 +100,10 @@ tokens {
 
 @members {
   def mismatch(self, input, ttype, follow):
-      raise MismatchedTokenException(ttype, input)
+    raise MismatchedTokenException(ttype, input)
 
   def recoverFromMismatchedToken(self, input, ttype, follow):
-      raise RecognitionException(ttype, input)
+    raise RecognitionException(ttype, input)
 
   def recoverFromMismatchedToken(self, input, ttype, follow):
     raise RecognitionException(ttype, input)
@@ -153,7 +153,7 @@ typeDefinition:
   xception;
 
 typedef:
-  'typedef' fieldType IDENTIFIER -> ^(TYPEDEF fieldType IDENTIFIER);
+  'typedef' fieldType IDENTIFIER typeAnnotations? -> ^(TYPEDEF fieldType IDENTIFIER typeAnnotations?);
 
 commaOrSemicolon:
   (',' | ';');

--- a/src/antlr/twitter/thrift/descriptors/AntlrThriftTreeWalker.g
+++ b/src/antlr/twitter/thrift/descriptors/AntlrThriftTreeWalker.g
@@ -156,10 +156,12 @@ typeDefinition:
   xception;
 
 typedef
-  : ^(TYPEDEF type_=fieldType IDENTIFIER) {
+  : ^(TYPEDEF type_=fieldType IDENTIFIER annotations_=typeAnnotations) {
       typedef_ = thrift_descriptors.Typedef()
       typedef_.typeId = type_.id
       typedef_.typeAlias = $IDENTIFIER.text
+      if annotations_ is not None:
+        typedef_.annotations = annotations_
       self._append('typedefs', typedef_)
       self._registerTypedef($IDENTIFIER, typedef_)
     }

--- a/src/python/twitter/pants/targets/python_tests.py
+++ b/src/python/twitter/pants/targets/python_tests.py
@@ -30,11 +30,11 @@ class PythonTests(PythonTarget):
       soft_dependencies: Whether or not we should ignore dependency resolution
                          errors for this test.  [Default: False]
     """
-    self.add_label('python')
-    self.add_label('tests')
     self._timeout = timeout
     self._soft_dependencies = bool(soft_dependencies)
     PythonTarget.__init__(self, name, sources, resources, dependencies)
+    self.add_label('python')
+    self.add_label('tests')
 
   @property
   def timeout(self):

--- a/src/thrift/com/twitter/thrift/descriptors/thrift_descriptors.thrift
+++ b/src/thrift/com/twitter/thrift/descriptors/thrift_descriptors.thrift
@@ -115,7 +115,8 @@ struct Type {
 
 struct Typedef {
   1: required string typeId,
-  2: required string typeAlias
+  2: required string typeAlias,
+  99: optional list<Annotation> annotations = []
 }
 
 // A registry of all the types referenced in a thrift program.

--- a/tests/python/twitter/thrift/descriptors/test_data/AnnotationTest.thrift
+++ b/tests/python/twitter/thrift/descriptors/test_data/AnnotationTest.thrift
@@ -35,7 +35,7 @@ exception foo_error {
   2: string error_msg
 } (foo = "bar")
 
-typedef string ( unicode.encoding = "UTF-16" ) non_latin_string
+typedef string ( unicode.encoding = "UTF-16" ) non_latin_string (foo="bar")
 typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
 
 enum weekdays {
@@ -59,3 +59,4 @@ senum seasons {
 service foo_service {
   void foo() ( foo = "bar" )
 } (a.b="c")
+

--- a/tests/python/twitter/thrift/descriptors/test_data/test_data.thrift
+++ b/tests/python/twitter/thrift/descriptors/test_data/test_data.thrift
@@ -11,7 +11,7 @@ smalltalk_category Thrift-Tutorial
 namespace * tutorial.for.all
 xsd_namespace "tutorial"
 
-typedef i32 MyInteger
+typedef i32 MyInteger (typedefannotation="foo")
 
 const i32 (basictypeannotation="foo") INT32CONSTANT = 9853
 const map cpp_type "MyMap" <string,string> (containertypeannotation="foo") MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}

--- a/tests/python/twitter/thrift/descriptors/test_data/test_data.thrift.golden
+++ b/tests/python/twitter/thrift/descriptors/test_data/test_data.thrift.golden
@@ -560,6 +560,12 @@
   },
   "typedefs": [
     {
+      "annotations": [
+        {
+          "key": "typedefannotation",
+          "value": "foo"
+        }
+      ],
       "typeAlias": "MyInteger",
       "typeId": "T0"
     }


### PR DESCRIPTION
I have made the corresponding change in the canonical thrift compiler:

https://issues.apache.org/jira/browse/THRIFT-1651

Also fixes a bug in python_tests.py.
