### PR TITLE
JUnit run tweaks - release lock, allow command line to be written to a file

### DIFF
--- a/src/java/com/twitter/common/testing/runner/JUnitConsoleRunner.java
+++ b/src/java/com/twitter/common/testing/runner/JUnitConsoleRunner.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 
-import org.junit.experimental.ParallelComputer;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
@@ -214,15 +213,12 @@ public class JUnitConsoleRunner {
   private final boolean suppressOutput;
   private final boolean xmlReport;
   private final File outdir;
-  private final boolean parallelClasses;
 
-  JUnitConsoleRunner(boolean failFast, boolean suppressOutput, boolean xmlReport, File outdir,
-                     boolean parallelClasses) {
+  JUnitConsoleRunner(boolean failFast, boolean suppressOutput, boolean xmlReport, File outdir) {
     this.failFast = failFast;
     this.suppressOutput = suppressOutput;
     this.xmlReport = xmlReport;
     this.outdir = outdir;
-    this.parallelClasses = parallelClasses;
   }
 
   void run(Iterable<String> tests) {
@@ -318,8 +314,7 @@ public class JUnitConsoleRunner {
     }
     List<Request> requests = Lists.newArrayList();
     if (!classes.isEmpty()) {
-      requests.add(Request.classes(ParallelComputer.classes(),
-                                   classes.toArray(new Class<?>[classes.size()])));
+      requests.add(Request.classes(classes.toArray(new Class<?>[classes.size()])));
     }
     for (TestMethod testMethod : testMethods) {
       requests.add(Request.method(testMethod.clazz, testMethod.name));
@@ -341,7 +336,6 @@ public class JUnitConsoleRunner {
      */
     class Options {
       private boolean failFast = false;
-      private boolean parallelClasses = false;
       private boolean suppressOutput = false;
       private boolean xmlReport = false;
       private File outdir = new File(System.getProperty("java.io.tmpdir"));
@@ -350,11 +344,6 @@ public class JUnitConsoleRunner {
       @Option(name = "-fail-fast", usage = "Causes the test suite run to fail fast.")
       public void setFailFast(boolean failFast) {
         this.failFast = failFast;
-      }
-
-      @Option(name = "-parallel-classes", usage = "Runs test classes in parallel.")
-      public void setParallelClasses(boolean parallelClasses) {
-        this.parallelClasses = parallelClasses;
       }
 
       @Option(name = "-suppress-output", usage = "Suppresses test output.")
@@ -399,8 +388,7 @@ public class JUnitConsoleRunner {
         new JUnitConsoleRunner(options.failFast,
             options.suppressOutput,
             options.xmlReport,
-            options.outdir,
-            options.parallelClasses);
+            options.outdir);
 
     List<String> tests = Lists.newArrayList();
     for (String test : options.tests) {

--- a/src/python/twitter/pants/tasks/junit_run.py
+++ b/src/python/twitter/pants/tasks/junit_run.py
@@ -120,11 +120,6 @@ class JUnitRun(JvmTask):
                             help = "[%%default] Redirects test output to files in %s.  "
                                    "Implied by %s" % (outdir, xmlreport))
 
-    option_group.add_option(mkflag("parallel-classes"), mkflag("parallel-classes", negate=True),
-                            dest = "junit_run_parallel_classes",
-                            action="callback", callback=mkflag.set_bool, default=False,
-                            help = "[%%default] Runs test classes in parallel")
-
   def __init__(self, context):
     Task.__init__(self, context)
 
@@ -182,10 +177,9 @@ class JUnitRun(JvmTask):
       self.flags.append('-suppress-output')
       self.flags.append('-outdir')
       self.flags.append(self.outdir)
-    if context.options.junit_run_parallel_classes:
-      self.flags.append('-parallel-classes')
 
     self.only_write_cmd_line = context.options.only_write_cmd_line
+
 
   def execute(self, targets):
     if not self.context.options.junit_run_skip:


### PR DESCRIPTION
- release the lock before running tests, just as pants run does.
- add command-line-writing support to junit tasks. if
  --junit-only-write-cmd-line is passed to pants test, then instead of
  running java, pants will write the command line to the specified
  file.
