### PR TITLE
Support for 'test-jar' jar dependencies

### DIFF
--- a/src/python/twitter/pants/targets/jar_dependency.py
+++ b/src/python/twitter/pants/targets/jar_dependency.py
@@ -39,7 +39,7 @@ class JarDependency(object):
   javadocs with {@link}s to the jar's classes will be properly hyperlinked.
   """
 
-  def __init__(self, org, name, rev = None, force = False, ext = None, url = None, apidocs = None):
+  def __init__(self, org, name, rev = None, force = False, ext = None, url = None, apidocs = None, test_jar = False):
     self.org = org
     self.name = name
     self.rev = rev
@@ -50,6 +50,7 @@ class JarDependency(object):
     self.url = url
     self.apidocs = apidocs
     self.id = None
+    self.test_jar = test_jar
     self._configurations = [ 'default' ]
 
     # Support legacy method names

--- a/src/python/twitter/pants/tasks/ivy_resolve.py
+++ b/src/python/twitter/pants/tasks/ivy_resolve.py
@@ -251,6 +251,7 @@ class IvyResolve(NailgunTask):
       transitive = jar.transitive,
       ext = jar.ext,
       url = jar.url,
+      test_jar = jar.test_jar,
       configurations = ';'.join(jar._configurations),
     )
     override = self._overrides.get((jar.org, jar.name))

--- a/src/python/twitter/pants/tasks/ivy_resolve/ivy.mk
+++ b/src/python/twitter/pants/tasks/ivy_resolve/ivy.mk
@@ -79,6 +79,10 @@ limitations under the License.
         % endif
       />
       % endif
+			% if dependency.test-jar: 
+			<artifact name="${dependency.module}" type="test-jar" ext="jar" m:classifier="tests"/>
+			<artifact name="${dependency.module}" type="jar" ext="jar" />
+			% endif
       % if dependency.excludes:
         % for exclude in dependency.excludes:
           % if exclude.name:


### PR DESCRIPTION
Adds the test_jar attribute to JarDependency, which creates an ivy dependency to pull in both the regular jar, and the test jar. 
