### PR TITLE
Fix target cycle detection.

### DIFF
--- a/src/python/twitter/pants/commands/build.py
+++ b/src/python/twitter/pants/commands/build.py
@@ -77,11 +77,6 @@ class Build(Command):
       except:
         self.error("Problem parsing BUILD target %s: %s" % (address, traceback.format_exc()))
 
-      try:
-        InternalTarget.check_cycles(target)
-      except InternalTarget.CycleException as e:
-        self.error("Target contains an internal dependency cycle: %s" % e)
-
       if not target:
         self.error("Target %s does not exist" % address)
       if not target.address.is_meta:

--- a/src/python/twitter/pants/commands/goal.py
+++ b/src/python/twitter/pants/commands/goal.py
@@ -377,13 +377,6 @@ class Goal(Command):
   def run(self, lock):
     if self.options.dry_run:
       print '****** Dry Run ******'
-    with self.check_errors("Target contains a dependency cycle") as error:
-      with self.timer.timing('parse:check_cycles'):
-        for target in self.targets:
-          try:
-            InternalTarget.check_cycles(target)
-          except InternalTarget.CycleException as e:
-            error(target.id)
 
     logger = None
     if self.options.log or self.options.log_level:

--- a/tests/python/twitter/pants/targets/test-internal.py
+++ b/tests/python/twitter/pants/targets/test-internal.py
@@ -33,10 +33,10 @@ class InternalTargetTest(unittest.TestCase):
     a = MockTarget('a')
 
     # no cycles yet
-    InternalTarget.check_cycles(a)
-    a.internal_dependencies = [ a ]
+    InternalTarget.sort_targets([a])
+    a.internal_dependencies = [a]
     try:
-      InternalTarget.check_cycles(a)
+      InternalTarget.sort_targets([a])
       self.fail("Expected a cycle to be detected")
     except InternalTarget.CycleException:
       # expected
@@ -48,11 +48,11 @@ class InternalTargetTest(unittest.TestCase):
     a = MockTarget('a', c, b)
 
     # no cycles yet
-    InternalTarget.check_cycles(a)
+    InternalTarget.sort_targets([a])
 
-    c.internal_dependencies = [ a ]
+    c.internal_dependencies = [a]
     try:
-      InternalTarget.check_cycles(a)
+      InternalTarget.sort_targets([a])
       self.fail("Expected a cycle to be detected")
     except InternalTarget.CycleException:
       # expected


### PR DESCRIPTION
The old cycle detection applied before any codegen synthetic
targets were added.

This folds cycle detection into the topological sort, where it belongs.
