### PR TITLE
Be more careful when injecting sibling resource dirs.

### DIFF
--- a/src/python/twitter/pants/tasks/jvm_task.py
+++ b/src/python/twitter/pants/tasks/jvm_task.py
@@ -34,9 +34,11 @@ class JvmTask(Task):
     bases = set()
     for target in self.context.targets():
       if isinstance(target, JvmTarget) and (is_test(target) or hasattr(target, 'resources')):
-        if target.target_base not in bases:
-          sibling_resources_base = os.path.join(os.path.dirname(target.target_base), 'resources')
-          classpath.append(os.path.join(get_buildroot(), sibling_resources_base))
-          bases.add(target.target_base)
+        sibling_resources_base = os.path.join(os.path.dirname(target.target_base), 'resources')
+        if sibling_resources_base not in bases:
+          sibling_resources_full_path = os.path.join(get_buildroot(), sibling_resources_base)
+          if os.path.isdir(sibling_resources_full_path):
+            classpath.append(sibling_resources_full_path)
+          bases.add(sibling_resources_base)
 
     return classpath


### PR DESCRIPTION
Two changes:
1. Prevent multiple bases that are siblings from injecting the
   same 'resources' sibling multiple times.
2. Only inject if the dir exists.

This mitigates a problem that was exposed by a bug in our
BUILD.bootstrap, whereby we hadn't registered scala_tests in
our tests/ source root. In this case the base is set to the
target's parent dir...
