### PR TITLE
more robust dependency injection in target ctors

### DIFF
--- a/src/python/twitter/pants/targets/scala_library.py
+++ b/src/python/twitter/pants/targets/scala_library.py
@@ -67,6 +67,11 @@ class ScalaLibrary(ExportableJvmLibrary):
 
     self.deployjar = deployjar
 
+    # All scala targets implicitly depend on the selected scala runtime.
+    for spec in self._config.getlist('scala-compile', 'scaladeps'):
+      self.add_injected_dependency(spec)
+
+
   def _create_template_data(self):
     allsources = []
     if self.sources:
@@ -80,3 +85,4 @@ class ScalaLibrary(ExportableJvmLibrary):
       deploy_jar = self.deployjar,
       allsources = allsources,
     )
+

--- a/src/python/twitter/pants/tasks/__init__.py
+++ b/src/python/twitter/pants/tasks/__init__.py
@@ -131,7 +131,7 @@ class Task(object):
       extra_data.append(sha.hexdigest())
 
     cache_manager = CacheManager(self._cache_key_generator, self._build_invalidator_dir,
-      invalidate_dependents, extra_data, only_buildfiles)
+      invalidate_dependents, extra_data, only_externaldeps=only_buildfiles)
 
     invalidation_check = cache_manager.check(targets, partition_size_hint)
 

--- a/src/python/twitter/pants/tasks/scala_compile.py
+++ b/src/python/twitter/pants/tasks/scala_compile.py
@@ -108,13 +108,6 @@ class ScalaCompile(NailgunTask):
 
     self._plugin_jars = nailgun_profile_classpath(self, plugins_profile) if plugins_profile else []
 
-    # All scala targets implicitly depend on the selected scala runtime.
-    scaladeps = []
-    for spec in context.config.getlist('scala-compile', 'scaladeps'):
-      scaladeps.extend(context.resolve(spec))
-    for target in context.targets(is_scala):
-      target.update_dependencies(scaladeps)
-
     self._workdir = context.config.get('scala-compile', 'workdir') if workdir is None else workdir
     self._classes_dir = os.path.join(self._workdir, 'classes')
     self._analysis_cache_dir = os.path.join(self._workdir, 'analysis_cache')
@@ -184,7 +177,7 @@ class ScalaCompile(NailgunTask):
       upstream_cache_files = set()
       for (_, cache_list_entry) in upstream_analysis_caches.itermappings():
         for d in cache_list_entry.keys():
-          for cache in cache_list_entry[d]: 
+          for cache in cache_list_entry[d]:
             upstream_cache_files.add(os.path.join(d, cache))
 
       deps_cache = JvmDependencyCache(self, scala_targets, upstream_cache_files)


### PR DESCRIPTION
Sometimes, codegen targets synthesize ScalaLibrary targets after
ScalaCompile.**init** has already run, meaning they don't get
mandatory scala runtime dependencies injected into their dependency
list.

This change makes the ScalaLibrary constructor handle reading these
dependencies from config file and adding them to all ScalaLibrary
targets, with appropriate hooks in InternalTarget to allow other target
types to behave similarly.
