### PR TITLE
Default scala_library sources to globs('*.scala')

### DIFF
--- a/src/python/twitter/pants/targets/scala_library.py
+++ b/src/python/twitter/pants/targets/scala_library.py
@@ -16,6 +16,7 @@
 
 import os
 
+from twitter.pants import globs
 from twitter.pants.targets import resolve_target_sources
 from twitter.pants.targets.exportable_jvm_library import ExportableJvmLibrary
 
@@ -23,7 +24,7 @@ class ScalaLibrary(ExportableJvmLibrary):
   """Defines a target that produces a scala library."""
 
   def __init__(self, name,
-               sources = None,
+               sources = globs('*.scala'),
                java_sources = None,
                provides = None,
                dependencies = None,


### PR DESCRIPTION
The current default (no sources) doesn't make much sense (such
a library should just be declared as a dependencies() wrapper).

globs('*.scala') contributes to a clean 1:1:1 relationship
between targets, packages, and directories.
