### PR TITLE
Add ParseContext hook for adding exec globals

### DIFF
--- a/src/python/twitter/pants/base/parse_context.py
+++ b/src/python/twitter/pants/base/parse_context.py
@@ -39,8 +39,16 @@ class ParseContext(object):
     "from twitter.pants import *",
     "from twitter.common.quantity import Amount, Time",
   ]
+
   @classmethod
   def add_to_exec_context(cls, str_to_exec):
+    """This hook allows for adding symbols to the execution context in which BUILD files are
+    parsed. This should only be used for importing symbols that are used fairly ubiquitously in
+    BUILD files, and possibly for appending to sys.path to get local python code on the python
+    path.
+
+    This will be phased out in favor of a more robust plugin architecture that supports import
+    injection and path amendment."""
     cls._strs_to_exec.append(str_to_exec)
 
   @staticmethod


### PR DESCRIPTION
Hey John, as I mentioned, I didn't see an obvious way to put foursquare-specific globals in the exec context of ParseContext, so I added this hook.

I am using it locally in our top-level BUILD.bootstrap file like so:

  ParseContext.add_to_exec_context('from foursquare.pants import scala_record_library')

to save us having to type that import at the top of 100s of BUILD files.

Let me know if this looks OK to you or if there is an easier way that I've missed to get the same result.

Thanks!
