### PR TITLE
add default arg for context.py requested_goals

### DIFF
--- a/src/python/twitter/pants/goal/context.py
+++ b/src/python/twitter/pants/goal/context.py
@@ -43,7 +43,7 @@ class Context(object):
     def info(self, msg): pass
     def warn(self, msg): pass
 
-  def __init__(self, config, options, target_roots, requested_goals, lock=Lock.unlocked(), log=None, timer=None):
+  def __init__(self, config, options, target_roots, requested_goals=None, lock=Lock.unlocked(), log=None, timer=None):
     self._config = config
     self._options = options
     self._lock = lock
@@ -52,7 +52,7 @@ class Context(object):
     self._products = Products()
     self._buildroot = get_buildroot()
     self.timer = timer
-    self.requested_goals = requested_goals
+    self.requested_goals = requested_goals or []
 
     self.replace_targets(target_roots)
 


### PR DESCRIPTION
reviving davidt's stalled pull request: https://github.com/tinystatemachine/twitter-commons/commit/6401abb2df3bb927ad7180be4b2b73488870da59

uses non-mutable default arg.
