### PR TITLE
Ensure InterruptedException is handled properly

### DIFF
--- a/src/java/com/twitter/common/zookeeper/ZooKeeperMap.java
+++ b/src/java/com/twitter/common/zookeeper/ZooKeeperMap.java
@@ -173,6 +173,7 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
           }
         } catch (InterruptedException e) {
           LOG.log(Level.WARNING, "Interrupted while trying to re-establish watch.", e);
+          Thread.currentThread().interrupt();
         }
       }
     });
@@ -263,6 +264,7 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
             tryWatchChildren();
           } catch (InterruptedException e) {
             LOG.log(Level.WARNING, "Interrupted while trying to watch children.", e);
+            Thread.currentThread().interrupt();
           }
         }
       }});
@@ -275,6 +277,7 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
             tryWatchChildren();
           } catch (InterruptedException e) {
             LOG.log(Level.WARNING, "Interrupted while trying to watch children.", e);
+            Thread.currentThread().interrupt();
           }
         }
       }
@@ -310,6 +313,7 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
             tryAddChild(child);
           } catch (InterruptedException e) {
             LOG.log(Level.WARNING, "Interrupted while trying to add a child.", e);
+            Thread.currentThread().interrupt();
           }
         } else if (event.getType() == Watcher.Event.EventType.NodeDeleted) {
           removeEntry(child);

--- a/src/java/com/twitter/common/zookeeper/ZooKeeperNode.java
+++ b/src/java/com/twitter/common/zookeeper/ZooKeeperNode.java
@@ -196,7 +196,6 @@ public class ZooKeeperNode<T> implements Supplier<T> {
       }
     } catch (InterruptedException e) {
       zkClient.unregister(watcher);
-      Thread.currentThread().interrupt();
       throw e;
     } catch (KeeperException e) {
       zkClient.unregister(watcher);
@@ -249,6 +248,7 @@ public class ZooKeeperNode<T> implements Supplier<T> {
             tryWatchDataNode();
           } catch (InterruptedException e) {
             LOG.log(Level.WARNING, "Interrupted while trying to watch a data node.", e);
+            Thread.currentThread().interrupt();
           }
         } else {
           LOG.info("Ignoring watcher event " + event);


### PR DESCRIPTION
There were a few cases where InterruptedException is caught but the
interrupted status wasn't being set, and one other place where the
exception was being rethrown so setting the interrupt flag wasn't
necessary.
