### PR TITLE
monkeypatch pkg_resources.build_zipmanifest in an EggZipImport friendly way

### DIFF
--- a/src/python/twitter/common/python/pex_builder.py
+++ b/src/python/twitter/common/python/pex_builder.py
@@ -160,7 +160,7 @@ class PEXBuilder(object):
     """
     bare_env = pkg_resources.Environment()
 
-    distribute_req = pkg_resources.Requirement.parse('distribute>=0.6.24,<0.6.41')
+    distribute_req = pkg_resources.Requirement.parse('distribute>=0.6.24')
     distribute_dist = None
 
     for dist in DistributionHelper.all_distributions(sys.path):


### PR DESCRIPTION
This is a stop-gap fix to allow PEX files to work with distribute >= 0.6.41 and setuptools >= 0.7

I will ping Brett about the build_zipmanifest stuff to see if there isn't a sane way around this hack.
