### PR TITLE
Fix a typo in pex.py 

### DIFF
--- a/src/python/twitter/common/python/pex.py
+++ b/src/python/twitter/common/python/pex.py
@@ -101,7 +101,7 @@ class PEX(object):
       TRACER.log('Found site-library: %s' % site_lib)
     for extras_path in cls._extras_paths():
       TRACER.log('Found site extra: %s' % extras_path)
-      site_libs.add(extra_paths)
+      site_libs.add(extras_path)
     site_libs = set(os.path.normpath(path) for path in site_libs)
 
     site_distributions = OrderedSet()


### PR DESCRIPTION
This now compiles without throwing  a nameerror
