### PR TITLE
Fixup bootstrap script to point to https://pypi.python.org and fixup handling of meta-distributions

### DIFF
--- a/build-support/python/setup.sh
+++ b/build-support/python/setup.sh
@@ -33,7 +33,7 @@ pushd $CACHE >& /dev/null
   if ! test -f virtualenv-1.7.1.2.tar.gz; then
     echo 'Installing virtualenv' 1>&2
     for url in \
-      http://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.7.1.2.tar.gz \
+      https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.7.1.2.tar.gz \
       https://svn.twitter.biz/science-binaries/home/third_party/python/virtualenv-1.7.1.2.tar.gz; do
       if curl --connect-timeout 10 -O $url; then
         break
@@ -49,7 +49,7 @@ if $PYTHON $CACHE/virtualenv-1.7.1.2/virtualenv.py -p $PY --distribute $BOOTSTRA
     pip install \
       --download-cache=$CACHE \
       -f https://svn.twitter.biz/science-binaries/home/third_party/python \
-      -f http://pypi.python.org/simple \
+      -f https://pypi.python.org/simple \
       -U --no-index $pkg
   done
   deactivate

--- a/pants.ini
+++ b/pants.ini
@@ -364,7 +364,7 @@ download_cache: %(pants_workdir)s/python/downloads
 install_cache: %(pants_workdir)s/python/eggs
 
 virtualenv_target: %(bootstrap_cache)s/virtualenv-1.7.1.2
-virtualenv_urls: ['http://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.7.1.2.tar.gz']
+virtualenv_urls: ['https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.7.1.2.tar.gz']
 bootstrap_packages: ['pip', 'pystache']
 
 platforms: ['current']
@@ -374,7 +374,7 @@ platforms: ['current']
 repos: [
   'https://raw.github.com/twitter/commons/binaries/pants/third_party/python/dist/index.html']
 
-indices: ['pypi.python.org']
+indices: ['https://pypi.python.org']
 
 allow_pypi: True
 

--- a/src/python/twitter/common/python/distiller.py
+++ b/src/python/twitter/common/python/distiller.py
@@ -161,8 +161,6 @@ class Distiller(object):
       'twitter.common.python.installer, or is an already-distilled .egg.')
 
     self._top_levels = self._get_lines('top_level.txt')
-    assert len(self._top_levels) > 0
-
     self._installed_files = [
       os.path.realpath(os.path.join(self._dist.egg_info, fn)) for fn in
         self._get_lines('installed-files.txt')]
@@ -265,6 +263,8 @@ class Distiller(object):
     yield pez_info_name('not-zip-safe' if unsafe_source else 'zip-safe'), ''
 
   def distill(self, into=None, strip_pyc=False):
+    if not self._top_levels:
+      self._log('Installing meta package %s' % self._package_name())
     native_deps = self._native_deps()
 
     if into is not None:


### PR DESCRIPTION
Fixup bootstrap script to point to https://pypi.python.org and fix plumbing to allow said-same for distribution resolution.

Also fixup an over-aggressive assert.  Some distributions, like
distribute 0.7.3, just serve as a dependency alias and export no top
level packages.
