### PR TITLE
Pass exclusives up in WithLegacyResources.

### DIFF
--- a/src/python/twitter/pants/targets/resources.py
+++ b/src/python/twitter/pants/targets/resources.py
@@ -31,8 +31,8 @@ class WithLegacyResources(TargetWithSources):
   """Collects resources whether they are specified using globs against an assumed parallel
   'resources' directory or they are Resources targets
   """
-  def __init__(self, name, sources=None, resources=None):
-    TargetWithSources.__init__(self, name, sources=sources)
+  def __init__(self, name, sources=None, resources=None, exclusives=None):
+    TargetWithSources.__init__(self, name, sources=sources, exclusives=exclusives)
 
     if resources is not None:
       def is_resources(item):


### PR DESCRIPTION
Encountered this issue when running tests for the java pingpong example:

```
$ ./pants goal test tests/java/com/twitter/common/examples/pingpong
:snip:

The following targets could not be loaded:
  tests/java/com/twitter/common/examples/pingpong =>
      File "/Users/bill/code/commons/src/java/com/twitter/common/args/BUILD", line 40, in <module>
          sources = CORE_SOURCES,
      TypeError: __init__() got an unexpected keyword argument 'exclusives'
```

The patch allows tests to run as expected.
