### PR TITLE
Add a jvm_app target to pingpong example to work around issues/160

### DIFF
--- a/src/java/com/twitter/common/examples/pingpong/BUILD
+++ b/src/java/com/twitter/common/examples/pingpong/BUILD
@@ -43,3 +43,9 @@ jvm_binary(name='pingpong',
     pants(':pingpong-lib')
   ]
 )
+
+jvm_app(name='pingpong-app',
+  basename='pingpong',
+  binary=pants(':pingpong'),
+  bundles=bundle()
+)


### PR DESCRIPTION
Please see issue https://github.com/twitter/commons/issues/160 for context.  This provides a workaround for pingpong due to resources missing from the classpath.
