### PR TITLE
Resource loading seems to be broken with `pants goal run` and `pants goal test`

### DIFF
--- a/rebuild_and_run.py
+++ b/rebuild_and_run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import subprocess
+
+def _print_loudly(msg):
+  prefix = "*" * 5
+  print prefix
+  print prefix + " " + msg
+  print prefix
+
+
+_print_loudly("Rebuilding pants.")
+subprocess.call('rm -rf pants.pex .pants.d', shell=True)
+subprocess.call('./pants', shell=True)
+
+_print_loudly("Building and running from binary deploy jar.")
+subprocess.call("./pants goal binary --binary-deployjar src/java/com/foobar:example_bin",
+                shell=True)
+subprocess.call("java -jar ./dist/example_bin.jar", shell=True)
+
+_print_loudly("Running with pants goal run.")
+subprocess.call("./pants goal run src/java/com/foobar:example_bin", shell=True)
+
+_print_loudly("Running unit test.")
+subprocess.call("./pants goal test tests/java/com/foobar:example_test", shell=True)

--- a/src/java/com/foobar/BUILD
+++ b/src/java/com/foobar/BUILD
@@ -1,0 +1,17 @@
+java_library(
+  name = 'example_lib',
+  dependencies = [
+    '3rdparty:guava',
+  ],
+  sources = rglobs('*.java'),
+  resources = ['example.txt'],
+)
+
+jvm_binary(
+  name = 'example_bin',
+  dependencies = [
+    pants(':example_lib')
+  ],
+  main = 'com.foobar.Example'
+)
+

--- a/src/java/com/foobar/Example.java
+++ b/src/java/com/foobar/Example.java
@@ -1,0 +1,22 @@
+package com.foobar;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+
+public final class Example {
+
+  private Example() {
+  }
+
+  public static String loadResource() throws IOException {
+    URL resource = Resources.getResource(Example.class, "example.txt");
+    return Resources.toString(resource, Charsets.UTF_8);
+  }
+
+  public static void main(String[] args) throws IOException {
+    System.out.println("Resource Content: " + loadResource());
+  }
+}

--- a/src/resources/com/foobar/example.txt
+++ b/src/resources/com/foobar/example.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/tests/java/com/foobar/BUILD
+++ b/tests/java/com/foobar/BUILD
@@ -1,0 +1,8 @@
+java_tests(
+  name = 'example_test',
+  dependencies = [
+    '3rdparty:junit',
+    pants('src/java/com/foobar:example_lib'),
+  ],
+  sources = globs('*.java')
+)

--- a/tests/java/com/foobar/ExampleTest.java
+++ b/tests/java/com/foobar/ExampleTest.java
@@ -1,0 +1,12 @@
+package com.foobar;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExampleTest {
+  @Test
+  public void testLoadResources() throws Exception {
+    assertEquals("Hello, World!\n", Example.loadResource());
+  }
+}


### PR DESCRIPTION
Hello, it seems that resource loading has broken in a number of cases (somewhere between 9baac01 and HEAD).

This doesn't contain a fix, as I couldn't track it down, but it does include a test case to demonstrate the problem.

For a java library defined as follows:

```
java_library(
  name = 'example_lib',
  dependencies = [
    '3rdparty:guava',
  ],
  sources = rglobs('*.java'),
  resources = ['example.txt'],
)

jvm_binary(
  name = 'example_bin',
  dependencies = [
    pants(':example_lib')
  ],
  main = 'com.foobar.Example'
)
```

Invoking the binary via `pants goal run` fails.

```
$ ./pants goal run src/java/com/foobar:example_bin
...
...
11:58:50 00:01       [run]
                     Exception in thread "main" java.lang.IllegalArgumentException: resource example.txt relative to com.foobar.Example not found.
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:119)
    at com.google.common.io.Resources.getResource(Resources.java:203)
    at com.foobar.Example.loadResource(Example.java:15)
    at com.foobar.Example.main(Example.java:20)
```

Same with a test that depends on the library:

```
java_tests(
  name = 'example_test',
  dependencies = [
    '3rdparty:junit',
    pants('src/java/com/foobar:example_lib'),
  ],
  sources = globs('*.java')
)
```

```
$ ./pants goal test tests/java/com/foobar:example_test
...
                     .E
                     Time: 0.013
                     There was 1 failure:
                     1) testLoadResources(com.foobar.ExampleTest)
                     java.lang.IllegalArgumentException: resource example.txt relative to com.foobar.Example not found.
                        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:119)
                        at com.google.common.io.Resources.getResource(Resources.java:203)
                        at com.foobar.Example.loadResource(Example.java:15)
                        at com.foobar.ExampleTest.testLoadResources(ExampleTest.java:10)
                        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
                        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
                        at java.lang.reflect.Method.invoke(Method.java:597)
                        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
                        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
                        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
                        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
                        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:263)
                        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
                        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:47)
                        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
                        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
                        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
                        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
                        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
                        at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
                        at com.twitter.common.testing.runner.CompositeRequest.runChild(CompositeRequest.java:50)
                        at com.twitter.common.testing.runner.ConcurrentCompositeRequest$1$1.run(ConcurrentCompositeRequest.java:35)
                        at com.twitter.common.testing.runner.ConcurrentRunnerScheduler.finished(ConcurrentRunnerScheduler.java:82)
                        at com.twitter.common.testing.runner.ConcurrentCompositeRequest$1.evaluate(ConcurrentCompositeRequest.java:44)
                        at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
                        at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
                        at com.twitter.common.testing.runner.JUnitConsoleRunner.run(JUnitConsoleRunner.java:291)
                        at com.twitter.common.testing.runner.JUnitConsoleRunner.main(JUnitConsoleRunner.java:488)

                     FAILURES!!!
                     Tests run: 1,  Failures: 1

```

However, building a binary deploy jar works fine.

```
$ ./pants goal binary --binary-deployjar src/java/com/foobar:example_bin
$ java -jar ./dist/example_bin.jar
Resource Content: Hello, World!
...
```

Are we defining our resources in the wrong way or something?  Thanks!
