### PR TITLE
Fixup the checkstyle task to skip synthetic targets.

### DIFF
--- a/src/python/twitter/pants/__init__.py
+++ b/src/python/twitter/pants/__init__.py
@@ -196,6 +196,11 @@ def is_codegen(target):
   return target.has_label('codegen')
 
 
+def is_synthetic(target):
+  """Returns True if the target is a synthetic target injected by the runtime."""
+  return target.has_label('synthetic')
+
+
 def is_jar_library(target):
   """Returns True if the target is an external jar library."""
   return target.has_label('jars')
@@ -316,6 +321,7 @@ __all__ = (
   'is_jvm',
   'is_python',
   'is_scala',
+  'is_synthetic',
   'is_test',
   'jar',
   'jar_library',

--- a/src/python/twitter/pants/tasks/checkstyle.py
+++ b/src/python/twitter/pants/tasks/checkstyle.py
@@ -17,7 +17,7 @@
 import os
 
 from twitter.common.dirutil import safe_open
-from twitter.pants import is_codegen, is_java
+from twitter.pants import is_java, is_synthetic
 from twitter.pants.tasks import TaskError
 from twitter.pants.tasks.nailgun_task import NailgunTask
 
@@ -28,7 +28,7 @@ CHECKSTYLE_MAIN = 'com.puppycrawl.tools.checkstyle.Main'
 class Checkstyle(NailgunTask):
   @staticmethod
   def _is_checked(target):
-    return is_java(target) and not is_codegen(target)
+    return is_java(target) and not is_synthetic(target)
 
   @classmethod
   def setup_parser(cls, option_group, args, mkflag):


### PR DESCRIPTION
This fixes a regression introduced by changes in a489c3ad to
distinguish codegen targets like java_thrift_library from the
synthetic targets they inject to own generated code.

https://github.com/twitter/commons/issues/168
