### PR TITLE
Remove a superfluous encode() call.

### DIFF
--- a/src/python/twitter/common/python/util.py
+++ b/src/python/twitter/common/python/util.py
@@ -12,7 +12,7 @@ class DistributionHelper(object):
         for fn, content in DistributionHelper.walk_metadata(dist, full_fn):
           yield fn, content
       else:
-        yield os.path.join('EGG-INFO', full_fn[1:]), dist.get_metadata(full_fn).encode('utf-8')
+        yield os.path.join('EGG-INFO', full_fn[1:]), dist.get_metadata(full_fn)
 
   @staticmethod
   def walk_data(dist, path='/'):


### PR DESCRIPTION
dist.get_metadata() returns a string (NOT a unicode). It is not
logically sound to call encode('utf-8') on a string, only on a
unicode. In fact, string probably shouldn't have an encode() method
at all.
