### PR TITLE
Fixed NPE when one type of token is not present on TokenizedCharSequence 

### DIFF
--- a/src/java/com/twitter/common/text/token/TokenizedCharSequence.java
+++ b/src/java/com/twitter/common/text/token/TokenizedCharSequence.java
@@ -240,13 +240,15 @@ public class TokenizedCharSequence implements CharSequence {
 
     if (types.length == 1) {
       List<Token> tokens = typeToTokensMap.get(types[0]);
-      return (tokens != null) ? tokens : Lists.<Token>newArrayList();
+      return (tokens != null) ? tokens : Collections.<Token>emptyList();
     }
 
     List<Token> subtokens = Lists.newArrayList();
     for (TokenType type : types) {
       List<Token> tokens = typeToTokensMap.get(type);
-      subtokens.addAll((tokens != null) ? tokens : Lists.<Token>newArrayList());
+      if (tokens != null) {
+        subtokens.addAll(tokens);
+      }
     }
     return subtokens;
   }


### PR DESCRIPTION
When using TokenizedCharSequence, if a parsed tweet doesn't contains a specific type of token getTokensOf(TokenType... types) will return null. When called from getTokenStringsOf(TokenType... types) or within the for (TokenType type : types) loop it will result in a NullPointerException.

This change returns an empty list instead of null, which prevents the exception.
