### PR TITLE
Fix idea project resource patterns.

### DIFF
--- a/src/python/twitter/pants/tasks/idea_gen.py
+++ b/src/python/twitter/pants/tasks/idea_gen.py
@@ -205,7 +205,7 @@ class IdeaGen(IdeGen):
         jdk=self.java_jdk,
         language_level = 'JDK_1_%d' % self.java_language_level
       ),
-      resource_extensions=project.resource_extensions,
+      resource_extensions=list(project.resource_extensions),
       scala=scala,
       checkstyle_suppression_files=','.join(project.checkstyle_suppression_files),
       checkstyle_classpath=';'.join(project.checkstyle_classpath),


### PR DESCRIPTION
For a project that has a number of various resource files, this will now
generate:

"?_.json;?_.creds"

Rather than

?*{'.creds?': True, '.json': True}

Which Intellij (12) cannot interpret.
