### PR TITLE
Make source root target type specification optional.

### DIFF
--- a/src/python/twitter/pants/docs/SetUpRepo.md
+++ b/src/python/twitter/pants/docs/SetUpRepo.md
@@ -19,12 +19,14 @@ If your top-level `BUILD` file is `foo/BUILD` and your main Java code is in
 then your top-level `BUILD` file might look like
 
     # foo/BUILD
+    source_root('src/java')
+    source_root('src/javatest')
+
+Pants can optionally enforce that only allowed target types are in each source root:
+
+    # foo/BUILD
     source_root('src/java', annotation_processor, doc, jvm_binary, java_library, page)
     source_root('src/javatest', doc, java_library, java_tests, page)
-
-With this layout, if you build a `jvm_binary` target, it uses `src/java` as
-a base when figuring out whence to import `com.foo.amazing.service`; if you
-build a `java_library`, it uses `src/java` and `src/javatest` as bases.
 
 If your source tree is laid out for Maven, there's a shortcut function
 `maven_layout` that configures source roots for Maven's expected

--- a/src/python/twitter/pants/tasks/ide_gen.py
+++ b/src/python/twitter/pants/tasks/ide_gen.py
@@ -326,6 +326,8 @@ class ClasspathEntry(object):
 class SourceSet(object):
   """Models a set of source files."""
 
+  TEST_BASES = set()
+
   def __init__(self, root_dir, source_base, path, is_test):
     """
       root_dir: the full path to the root directory of the project containing this source set
@@ -339,6 +341,8 @@ class SourceSet(object):
     self.path = path
     self.is_test = is_test
     self._excludes = []
+    if is_test:
+      SourceSet.TEST_BASES.add(self.source_base)
 
   @property
   def excludes(self):


### PR DESCRIPTION
No need to actually pull it - its just for your perusal.
