### PR TITLE
Upgrade virtualenv, fix issue 181

### DIFF
--- a/build-support/python/setup.sh
+++ b/build-support/python/setup.sh
@@ -5,6 +5,7 @@ BOOTSTRAP_BIN=$BASE_DIR/.python/bin
 BOOTSTRAP_ENVIRONMENT=$BASE_DIR/.python/bootstrap
 CACHE=$BASE_DIR/.pants.d/.pip.cache
 PY=$(which python)
+VIRTUALENV_VERSION=1.9.1
 
 mkdir -p $BOOTSTRAP_BIN
 mkdir -p $BOOTSTRAP_ENVIRONMENT
@@ -30,21 +31,17 @@ fi
 PYTHON=$BOOTSTRAP_BIN/bootstrap
 
 pushd $CACHE >& /dev/null
-  if ! test -f virtualenv-1.7.1.2.tar.gz; then
+  VIRTUALENV_TARBALL=virtualenv-$VIRTUALENV_VERSION.tar.gz
+  if ! test -f $VIRTUALENV_TARBALL; then
     echo 'Installing virtualenv' 1>&2
-    for url in \
-      https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.7.1.2.tar.gz \
-      https://svn.twitter.biz/science-binaries/home/third_party/python/virtualenv-1.7.1.2.tar.gz; do
-      if curl --connect-timeout 10 -O $url; then
-        break
-      fi
-    done
+    curl --connect-timeout 10 -O \
+        https://pypi.python.org/packages/source/v/virtualenv/$VIRTUALENV_TARBALL
   fi
-  gzip -cd virtualenv-1.7.1.2.tar.gz | tar -xf - >& /dev/null
+  gzip -cd $VIRTUALENV_TARBALL | tar -xf - >& /dev/null
 popd >& /dev/null
 
 function virtualenv() {
-  $PYTHON $CACHE/virtualenv-1.7.1.2/virtualenv.py "$@"
+  $PYTHON $CACHE/virtualenv-$VIRTUALENV_VERSION/virtualenv.py "$@"
 }
 
 if virtualenv -p $PY --distribute $BOOTSTRAP_ENVIRONMENT; then
@@ -55,7 +52,6 @@ if virtualenv -p $PY --distribute $BOOTSTRAP_ENVIRONMENT; then
   for pkg in distribute pystache; do
     pip install \
       --download-cache=$CACHE \
-      -f https://svn.twitter.biz/science-binaries/home/third_party/python \
       -f https://pypi.python.org/simple \
       -U --no-index $pkg
   done


### PR DESCRIPTION
This commit fixes #181 by upgrading `virtualenv` to the 1.9 release series.

I also removed references to internal twitter servers that don't resolve publicly.

There's a bug in `virtualenv` 1.7, as documented here: https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1115466

The Ubuntu thread offers a workaround, but upgrading `virtualenv` fixes the problem.

This commit passes all `pants` tests on my development VM:

```
=========================================================================== 76 passed in 0.72 seconds ============================================================================
tests.python.twitter.pants.base.base                                            .....   SUCCESS
tests.python.twitter.pants.buildtimestats.buildtimestats                        .....   SUCCESS
tests.python.twitter.pants.cache.cache                                          .....   SUCCESS
tests.python.twitter.pants.commands.commands                                    .....   SUCCESS
tests.python.twitter.pants.fs.fs                                                .....   SUCCESS
tests.python.twitter.pants.java.java                                            .....   SUCCESS
tests.python.twitter.pants.python.test_antlr_builder                            .....   SUCCESS
tests.python.twitter.pants.python.test_python_chroot                            .....   SUCCESS
tests.python.twitter.pants.python.test_subprocess_call_with_args                .....   SUCCESS
tests.python.twitter.pants.python.test_thrift_namespace_packages                .....   SUCCESS
tests.python.twitter.pants.reporting.reporting                                  .....   SUCCESS
tests.python.twitter.pants.scm.scm                                              .....   SUCCESS
tests.python.twitter.pants.targets.targets                                      .....   SUCCESS
tests.python.twitter.pants.tasks.tasks                                          .....   SUCCESS
tests.python.twitter.pants.utils                                                .....   SUCCESS
```
