### PR TITLE
Added the `getconfig` command

### DIFF
--- a/pants
+++ b/pants
@@ -49,12 +49,13 @@ if [ ! -e $VIRTUAL_PYTHON/bin/python ]; then
 fi
 
 if [ -z "${PANTS_DEV}" -a ! -e $MY_DIR/pants.pex ]; then
+  PANTS_DIST_DIR=`run_pants_bare getconfig pants_distdir`
   run_pants_bare src/python/twitter/pants:pants
-  if [ ! -e $MY_DIR/dist/pants.pex ]; then
+  if [ ! -e $PANTS_DIST_DIR/pants.pex ]; then
     echo "Unable to build pants!  Cannot continue!"
     exit 1
   else
-    mv $MY_DIR/dist/pants.pex $MY_DIR/pants.pex
+    mv $PANTS_DIST_DIR/pants.pex $MY_DIR/pants.pex
     cp $MY_DIR/pants.pex $VIRTUAL_PYTHON/pants.pex
   fi
 fi

--- a/src/python/twitter/pants/commands/getconfig.py
+++ b/src/python/twitter/pants/commands/getconfig.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+
+__author__ = "Ted Dziuba"
+
+from . import Command
+
+from twitter.pants.base import Config
+
+class GetConfig(Command):
+    """Prints the value of the specified configuration variable to standard output."""
+
+    __command__ = "getconfig"
+
+    def setup_parser(self, parser, args):
+        parser.set_usage("\n"
+                         " %prog getconfig [varname]\n"
+                         " %prog getconfig [section] [varname]")
+
+        parser.epilog = ("Prints the value of a configuration variable "
+                         "to standard output.")
+
+    def __init__(self, run_tracker, root_dir, parser, argv):
+        Command.__init__(self, run_tracker, root_dir, parser, argv)
+        self.varname = None
+        self.section = Config.DEFAULT_SECTION
+
+        if not self.args:
+            self.error("A varname argument is required.")
+
+        elif len(self.args) == 1:
+            self.varname = self.args[0]
+
+        elif len(self.args) == 2:
+            self.section = self.args[0]
+            self.varname = self.args[1]
+
+        elif len(self.args) > 2:
+            self.error("Only [section] and [varname] may be specified")
+
+
+    def execute(self):
+        config = Config.load()
+        value = config.get(self.section, self.varname)
+        if value is None:
+            self.error("No value is defined for [section='%s'] [varname='%s']"
+                       % (self.section, self.varname), show_help=False)
+        else:
+            print(value)


### PR DESCRIPTION
This command prints a pants configuration variable on standard output.

This fixes a bug that would cause the build of pants itself to fail if you specify an alternate `pants_distdir` in `pants.ini` before invoking the `pants` shell script that builds the pants .pex file.

Very meta.
