### PR TITLE
Use a CopyOnWriteHashSet to avoid CME.

### DIFF
--- a/src/java/com/twitter/common/zookeeper/ZooKeeperClient.java
+++ b/src/java/com/twitter/common/zookeeper/ZooKeeperClient.java
@@ -18,9 +18,8 @@ package com.twitter.common.zookeeper;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -177,7 +176,7 @@ public class ZooKeeperClient {
   private volatile ZooKeeper zooKeeper;
   private SessionState sessionState;
 
-  private final Set<Watcher> watchers = Collections.synchronizedSet(new HashSet<Watcher>());
+  private final Set<Watcher> watchers = new CopyOnWriteArraySet<Watcher>();
 
   private static Iterable<InetSocketAddress> combine(InetSocketAddress address,
       InetSocketAddress... addresses) {
@@ -314,10 +313,8 @@ public class ZooKeeperClient {
               }
           }
 
-          synchronized (watchers) {
-            for (Watcher watcher : watchers) {
-              watcher.process(event);
-            }
+          for (Watcher watcher : watchers) {
+            watcher.process(event);
           }
         }
       };


### PR DESCRIPTION
Switch from a synchronized HashSet to a CopyOnWriteHashSet to avoid
ConcurrentModificationException when processing watchers.

This avoids exceptions like the following:

ERROR org.apache.zookeeper.ClientCnxn: Error while calling watcher
! java.util.ConcurrentModificationException: null
! at java.util.HashMap$HashIterator.nextEntry(Unknown Source)
! at java.util.HashMap$KeyIterator.next(Unknown Source)
! at com.twitter.common.zookeeper.ZooKeeperClient$2.process(
ZooKeeperClient.java:318)
! at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(
ClientCnxn.java:526)
