### PR TITLE
Staked bootstrapping distribute version

### DIFF
--- a/src/python/twitter/common/python/pex_builder.py
+++ b/src/python/twitter/common/python/pex_builder.py
@@ -156,7 +156,7 @@ class PEXBuilder(object):
     """
     bare_env = pkg_resources.Environment()
 
-    distribute_req = pkg_resources.Requirement.parse('distribute>=0.6.24')
+    distribute_req = pkg_resources.Requirement.parse('distribute==0.6.34')
     distribute_dist = None
 
     for dist in DistributionHelper.all_distributions(sys.path):
@@ -166,9 +166,16 @@ class PEXBuilder(object):
     else:
       raise DistributionNotFound('Could not find distribute!')
 
+    bootstrapped_distribute_lib = False
     for fn, content in DistributionHelper.walk_data(distribute_dist):
       if fn.startswith('pkg_resources.py') or fn.startswith('setuptools'):
         self._chroot.write(content, os.path.join(self.BOOTSTRAP_DIR, fn), 'resource')
+        bootstrapped_distribute_lib = True
+
+    if not bootstrapped_distribute_lib:
+      msg = "Could not find bootstrappable distribute! (Using a metapackage maybe?)"
+      raise DistributionNotFound(msg)
+
     libraries = (
       'twitter.common.dirutil',
       'twitter.common.collections',

--- a/src/python/twitter/pants/BUILD
+++ b/src/python/twitter/pants/BUILD
@@ -35,6 +35,7 @@ python_library(
     python_requirement('pytest'),
     python_requirement('pytest-cov'),
     python_requirement('python_daemon'),
+    python_requirement('distribute==0.6.34')
   ]
 )
 


### PR DESCRIPTION
This commit stakes the version of `distribute` that Pants depends on to `0.6.34`. It also adds a guard check against failure to bootstrap `pkg_resources.py` or `setuptools` into the Pants build.

The problem with using `distribute>=0.6.24` as a requirement is that it's possible to pick up `distribute>=0.7` which is actually a meta-package, and does not contain `pkg_resources.py` or `setuptools`, it simply declares `setuptools` as a dependency. Since the iteration to choose the `distribute` package to bootstrap in is eager, and happens in no particular order, this is a thing that could happen easily (it did on my build).

In normal `pip` land, there is no problem with this, but the way that Pants bootstraps `distribute` makes it difficult, since it doesn't pull in the transitive closure of dependencies, it simply iterates over the files in the `distribute` package and copies them to chroot.

In the case that it picks up `distribute>=0.7`, this results in there being no `pkg_resources.py` or `setuptools` copied into subsequent .pex files. Normally this would not cause any obvious problems, since most environments where a .pex file would run include `setuptools` in their system Python installations.

However, if you work where I do, the production machines are very slimly configured, and do not include a reasonable system Python. This results in the bootstrap script inside the .pex file to fail to import `pkg_resources.py`.
