### PR TITLE
Add a close() method to ZooKeeperMap.

### DIFF
--- a/src/java/com/twitter/common/zookeeper/ZooKeeperMap.java
+++ b/src/java/com/twitter/common/zookeeper/ZooKeeperMap.java
@@ -279,6 +279,16 @@ public class ZooKeeperMap<V> extends ForwardingMap<String, V> {
     }
   }
 
+  /**
+   * Unregisters all ZooKeeper watchers using
+   * {@link com.twitter.common.zookeeper.ZooKeeperClient#unregister(org.apache.zookeeper.Watcher)} and prevents any
+   * future mutations to the map or callbacks on the {@link com.twitter.common.zookeeper.ZooKeeperMap.Listener}, if
+   * provided.
+   *
+   * The current (frozen) state of the map is still available to callers via the standard {@link java.util.Map} methods.
+   *
+   * Existing watches currently set on ZooKeeper could still fire once more, however watches will not be re-established.   *
+   */
   public void close() {
     if (shutdown.compareAndSet(false, true)) {
       zkClient.unregister(expirationHandler);


### PR DESCRIPTION
Enable a ZooKeeperMap user to signal that it no longer requires the map
any longer by calling ZooKeeperMap.close(). This removes any persistent
watchers against ZooKeeperClient (allowing it to be GC'd), stops
registering any additional watchers against ZooKeeper, and prevents any
additional callbacks to the ZooKeeperMap.Listener interface.
