### PR TITLE
Fixup __init__.py

### DIFF
--- a/src/python/twitter/common/python/BUILD
+++ b/src/python/twitter/common/python/BUILD
@@ -29,7 +29,7 @@ python_library(
   ],
   provides = setup_py(
     name = 'twitter.common.python',
-    version = '0.4.0',
+    version = '0.4.1',
     description = "Twitter's Python packaging toolchain.",
     long_description = """
 Twitter's Python packaging libraries and toolchain for fetching,

--- a/src/python/twitter/common/python/__init__.py
+++ b/src/python/twitter/common/python/__init__.py
@@ -14,9 +14,3 @@
 # limitations under the License.
 # ==================================================================================================
 
-# TODO(John Sirois): This works around a bug in namespace package injection for the setup_py
-# command's sdist generation of a library using with_binaries.  In this case
-# the src/python/twitter/common/python target has a with_binaries that includes the pex.pex pex and
-# this __init__.py is emitted in the sdist with no namespace package by the setup_py command unless
-# manually added below.
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
I had added a manual namespace package and this no longer
appears necessary and in fact breaks pip installed pants
py & build commands when used to create pexes.

https://rbcommons.com/s/twitter/r/66/
