### PR TITLE
Cleanup pants.ini keys involved in pants bootstrapping.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -1,23 +1,18 @@
-# buildroot, homedir and user are seeded in the config
+# All of the following are seeded with defaults in the config
+#   user: the current user
+#   homedir: the current user's home directory
+#   buildroot: the root of this repo
+#   pants_bootstrapdir: the global pants scratch space primarily used for caches
+#   pants_supportdir: pants support files for this repo go here; for example: ivysettings.xml
+#   pants_distdir: user visible artifacts for this repo go here
+#   pants_workdir: the scratch space used to for live builds in this repo
 
 [DEFAULT]
-# Look for these rcfiles - they need not exist on the system
-rcfiles: ['/etc/pantsrc', '~/.pants.new.rc']
-
-pants_bootstrapdir: %(homedir)s/.pants.d
-
-pants_workdir: %(buildroot)s/.pants.d
-pants_supportdir: %(buildroot)s/build-support
-
 # TODO(John Sirois): Come up with a better public solution.
 pants_support_baseurl: http://maven.twttr.com/twitter-commons/pants/build-support
 pants_support_fetch_timeout_secs: 30
 
-pants_distdir: %(buildroot)s/dist
-pants_pythons: %(buildroot)s/.python
 max_subprocess_args: 100
-
-info_dir: %(pants_workdir)s/runs
 
 thrift_workdir: %(pants_workdir)s/thrift
 scrooge_workdir: %(pants_workdir)s/scrooge
@@ -47,10 +42,6 @@ write_artifact_caches: []
 cache_key_gen_version: '100'
 
 jvm_args: ['-Xmx1g', '-XX:MaxPermSize=256m']
-
-
-[reporting]
-reports_dir: %(pants_workdir)s/reports
 
 
 [goals]
@@ -337,19 +328,6 @@ workdir: %(pants_workdir)s/provides
 [idea]
 scala_maximum_heap_size_mb: 1024
 java_maximum_heap_size_mb: 1024
-
-
-[python-setup]
-artifact_cache: %(pants_workdir)s/python/artifacts
-bootstrap_cache: %(pants_workdir)s/python/pip
-download_cache: %(pants_workdir)s/python/downloads
-install_cache: %(pants_workdir)s/python/eggs
-interpreter_cache: %(pants_workdir)s/python/interpreters
-setuptools_version: 2.1
-
-virtualenv_target: %(bootstrap_cache)s/virtualenv-1.10.1
-virtualenv_urls: ['https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.10.1.tar.gz']
-bootstrap_packages: ['pip', 'pystache']
 
 
 [python-repos]

--- a/src/python/twitter/pants/base/config.py
+++ b/src/python/twitter/pants/base/config.py
@@ -53,16 +53,25 @@ class Config(object):
 
   @staticmethod
   def create_parser(defaults=None):
-    """
-      Creates a config parser that supports %([key-name])s value substitution.  Any defaults
-      supplied will act as if specified in the loaded config file's DEFAULT section and be available
-      for substitutions.  The 'buildroot', invoking 'user' and invoking user's 'homedir' are
-      automatically defaulted.
+    """Creates a config parser that supports %([key-name])s value substitution.
+
+    Any defaults supplied will act as if specified in the loaded config file's DEFAULT section and
+    be available for substitutions.
+
+    All of the following are seeded with defaults in the config
+      user: the current user
+      homedir: the current user's home directory
+      buildroot: the root of this repo
+      pants_bootstrapdir: the global pants scratch space primarily used for caches
+      pants_supportdir: pants support files for this repo go here; for example: ivysettings.xml
+      pants_distdir: user visible artifacts for this repo go here
+      pants_workdir: the scratch space used to for live builds in this repo
     """
     standard_defaults = dict(
       buildroot=get_buildroot(),
       homedir=os.path.expanduser('~'),
       user=getpass.getuser(),
+      pants_bootstrapdir=os.path.expanduser('~/.pants.d'),
       pants_workdir=os.path.join(get_buildroot(), '.pants.d'),
       pants_supportdir=os.path.join(get_buildroot(), 'build-support'),
       pants_distdir=os.path.join(get_buildroot(), 'dist')

--- a/src/python/twitter/pants/base/run_info.py
+++ b/src/python/twitter/pants/base/run_info.py
@@ -12,7 +12,18 @@ from .build_environment import get_scm, get_buildroot
 class RunInfo(object):
   """A little plaintext file containing very basic info about a pants run.
 
-  Can only be appended to, never edited."""
+  Can only be appended to, never edited.
+  """
+
+  @classmethod
+  def dir(cls, config):
+    """Returns the configured base directory run info files are stored under."""
+    # TODO(John Sirois): This is centralized, but in an awkward location.  Isolate RunInfo reading
+    # and writing in 1 package or class that could naturally know this location and synthesize
+    # info_file names.
+    return config.getdefault('info_dir',
+                             default=os.path.join(config.getdefault('pants_workdir'), 'runs'))
+
   def __init__(self, info_file):
     self._info_file = info_file
     safe_mkdir_for(self._info_file)

--- a/src/python/twitter/pants/bin/pants_exe.py
+++ b/src/python/twitter/pants/bin/pants_exe.py
@@ -75,7 +75,7 @@ section named for the subcommand in ini style format, ie:
 
 
 def _add_default_options(command, args):
-  expanded_options = RcFile(paths=['~/.pantsrc']).apply_defaults([command], args)
+  expanded_options = RcFile(paths=['/etc/pantsrc', '~/.pants.rc']).apply_defaults([command], args)
   if expanded_options != args:
     print("(using ~/.pantsrc expansion: pants %s %s)" % (command, ' '.join(expanded_options)),
           file=sys.stderr)

--- a/src/python/twitter/pants/binary_util.py
+++ b/src/python/twitter/pants/binary_util.py
@@ -63,7 +63,7 @@ def select_binary(base_path, version, name, config=None):
   """
   # TODO(John Sirois): finish doc of the path structure expexcted under base_path
   config = config or Config.load()
-  bootstrap_dir = config.getdefault('pants_bootstrapdir', default=os.path.expanduser('~/.pants.d'))
+  bootstrap_dir = config.getdefault('pants_bootstrapdir')
   baseurl = config.getdefault('pants_support_baseurl')
   timeout_secs = config.getdefault('pants_support_fetch_timeout_secs', type=int, default=30)
 

--- a/src/python/twitter/pants/commands/BUILD
+++ b/src/python/twitter/pants/commands/BUILD
@@ -98,6 +98,7 @@ python_library(
     pants('src/python/twitter/pants/base:config'),
     pants('src/python/twitter/pants/base:parse_context'),
     pants('src/python/twitter/pants/base:rcfile'),
+    pants('src/python/twitter/pants/base:run_info'),
     pants('src/python/twitter/pants/base:target'),
     pants('src/python/twitter/pants/base:workunit'),
     pants('src/python/twitter/pants/engine'),

--- a/src/python/twitter/pants/commands/goal.py
+++ b/src/python/twitter/pants/commands/goal.py
@@ -42,6 +42,7 @@ from twitter.pants.base.build_file import BuildFile
 from twitter.pants.base.config import Config
 from twitter.pants.base.parse_context import ParseContext
 from twitter.pants.base.rcfile import RcFile
+from twitter.pants.base.run_info import RunInfo
 from twitter.pants.base.target import Target, TargetDefinitionException
 from twitter.pants.base.workunit import WorkUnit
 from twitter.pants.commands import Command
@@ -396,7 +397,8 @@ class Goal(Command):
 
       self.phases = [Phase(goal) for goal in goals]
 
-      rcfiles = self.config.getdefault('rcfiles', type=list, default=[])
+      rcfiles = self.config.getdefault('rcfiles', type=list,
+                                       default=['/etc/pantsrc', '~/.pants.rc'])
       if rcfiles:
         rcfile = RcFile(rcfiles, default_prepend=False, process_default=True)
 
@@ -629,7 +631,7 @@ class RunServer(ConsoleTask):
         # but is allowed to block indefinitely on the server loop.
         if not os.fork():
           # Child process.
-          info_dir = self.context.config.getdefault('info_dir')
+          info_dir = RunInfo.dir(self.context.config)
           # If these are specified explicitly in the config, use those. Otherwise
           # they will be None, and we'll use the ones baked into this package.
           template_dir = self.context.config.get('reporting', 'reports_template_dir')

--- a/src/python/twitter/pants/goal/initialize_reporting.py
+++ b/src/python/twitter/pants/goal/initialize_reporting.py
@@ -18,7 +18,8 @@ def initial_reporting(config, run_tracker):
 
   Will be changed after we parse cmd-line flags.
   """
-  reports_dir = config.get('reporting', 'reports_dir')
+  reports_dir = config.get('reporting', 'reports_dir',
+                           default=os.path.join(config.getdefault('pants_workdir'), 'reports'))
   link_to_latest = os.path.join(reports_dir, 'latest')
   if os.path.exists(link_to_latest):
     os.unlink(link_to_latest)

--- a/src/python/twitter/pants/goal/run_tracker.py
+++ b/src/python/twitter/pants/goal/run_tracker.py
@@ -47,7 +47,7 @@ class RunTracker(object):
   def from_config(cls, config):
     if not isinstance(config, Config):
       raise ValueError('Expected a Config object, given %s of type %s' % (config, type(config)))
-    info_dir = config.getdefault('info_dir')
+    info_dir = RunInfo.dir(config)
     stats_upload_url = config.getdefault('stats_upload_url', default=None)
     num_foreground_workers = config.getdefault('num_foreground_workers', default=8)
     num_background_workers = config.getdefault('num_background_workers', default=8)

--- a/src/python/twitter/pants/python/BUILD
+++ b/src/python/twitter/pants/python/BUILD
@@ -7,6 +7,14 @@ page(
 )
 
 python_library(
+  name = 'python_setup',
+  sources = ['python_setup.py'],
+  dependencies = [
+    pants('src/python/twitter/pants/base:config'),
+  ]
+)
+
+python_library(
   name = 'antlr_builder',
   sources = ['antlr_builder.py'],
   dependencies = [
@@ -43,6 +51,7 @@ python_library(
   sources = ['interpreter_cache.py'],
   dependencies = [
     pants('3rdparty/python:setuptools'),
+    pants(':python_setup'),
     pants(':resolver'),
     pants('src/python/twitter/common/dirutil'),
     pants('src/python/twitter/common/python'),
@@ -65,6 +74,7 @@ python_library(
   sources = ['python_chroot.py'],
   dependencies = [
     pants(':antlr_builder'),
+    pants(':python_setup'),
     pants(':resolver'),
     pants(':thrift_builder'),
     pants('src/python/twitter/common/collections'),
@@ -84,6 +94,7 @@ python_library(
   name = 'resolver',
   sources = ['resolver.py'],
   dependencies = [
+    pants(':python_setup'),
     pants('src/python/twitter/common/collections'),
     pants('src/python/twitter/common/python'),
     pants('src/python/twitter/pants/targets:python'),

--- a/src/python/twitter/pants/python/interpreter_cache.py
+++ b/src/python/twitter/pants/python/interpreter_cache.py
@@ -29,6 +29,7 @@ from twitter.common.python.interpreter import (
 )
 from twitter.common.python.obtainer import Obtainer
 
+from .python_setup import PythonSetup
 from .resolver import crawler_from_config, fetchers_from_config
 
 from pkg_resources import Requirement
@@ -47,7 +48,7 @@ def resolve_interpreter(config, interpreter, requirement, logger=print):
   """Given a :class:`PythonInterpreter` and :class:`Config`, and a requirement,
      return an interpreter with the capability of resolving that requirement or
      None if it's not possible to install a suitable requirement."""
-  interpreter_cache = config.get('python-setup', 'interpreter_cache')
+  interpreter_cache = PythonInterpreterCache.cache_dir(config)
   interpreter_dir = os.path.join(interpreter_cache, str(interpreter.identity))
   if interpreter.satisfies(PythonCapability([requirement])):
     return interpreter
@@ -115,8 +116,12 @@ def resolve(config, interpreter, logger=print):
 
 
 class PythonInterpreterCache(object):
+  @staticmethod
+  def cache_dir(config):
+    return PythonSetup(config).scratch_dir('interpreter_cache', default_name='interpreters')
+
   def __init__(self, config, logger=None):
-    self._path = config.get('python-setup', 'interpreter_cache')
+    self._path = self.cache_dir(config)
     self._config = config
     safe_mkdir(self._path)
     self._interpreters = set()

--- a/src/python/twitter/pants/python/python_chroot.py
+++ b/src/python/twitter/pants/python/python_chroot.py
@@ -24,16 +24,13 @@ import sys
 import tempfile
 
 from twitter.common.collections import OrderedSet
-from twitter.common.decorators import lru_cache
 from twitter.common.dirutil import safe_mkdir, safe_rmtree
 from twitter.common.python.interpreter import PythonInterpreter
 from twitter.common.python.pex_builder import PEXBuilder
 from twitter.common.python.platforms import Platform
-from twitter.common.quantity import Amount, Time
 from twitter.pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
 from twitter.pants.base.config import Config
 from twitter.pants.base.parse_context import ParseContext
-from twitter.pants.base.target import TargetDefinitionException
 from twitter.pants.targets.python_antlr_library import PythonAntlrLibrary
 from twitter.pants.targets.python_binary import PythonBinary
 from twitter.pants.targets.python_library import PythonLibrary
@@ -42,6 +39,7 @@ from twitter.pants.targets.python_tests import PythonTests
 from twitter.pants.targets.python_thrift_library import PythonThriftLibrary
 
 from .antlr_builder import PythonAntlrBuilder
+from .python_setup import PythonSetup
 from .resolver import resolve_multi
 from .thrift_builder import PythonThriftBuilder
 
@@ -79,8 +77,9 @@ class PythonChroot(object):
     self._builder = builder or PEXBuilder(tempfile.mkdtemp(), interpreter=self._interpreter)
 
     # Note: unrelated to the general pants artifact cache.
-    self._egg_cache_root = os.path.join(self._config.get('python-setup', 'artifact_cache'),
-                                        str(self._interpreter.identity))
+    self._egg_cache_root = os.path.join(
+        PythonSetup(self._config).scratch_dir('artifact_cache', default_name='artifacts'),
+        str(self._interpreter.identity))
 
     self._key_generator = CacheKeyGenerator()
     self._build_invalidator = BuildInvalidator( self._egg_cache_root)

--- a/src/python/twitter/pants/python/python_setup.py
+++ b/src/python/twitter/pants/python/python_setup.py
@@ -1,0 +1,51 @@
+# ==================================================================================================
+# Copyright 2014 Twitter, Inc.
+# --------------------------------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this work except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file, or at:
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==================================================================================================
+
+import os
+
+
+class PythonSetup(object):
+  """A clearing house for configuration data needed by components setting up python environments."""
+
+  def __init__(self, config, section='python-setup'):
+    self._config = config
+    self._section = section
+
+  @property
+  def scratch_root(self):
+    """Returns the root scratch space for assembling python environments.
+
+    Components should probably carve out their own directory rooted here.  See `scratch_dir`.
+    """
+    return self._config.get(
+        self._section,
+        'cache_root',
+        default=os.path.join(self._config.getdefault('pants_workdir'), 'python'))
+
+  def scratch_dir(self, key, default_name=None):
+    """Returns a named scratch dir.
+
+    By default this will be a child of the `scratch_root` with the same name as the key.
+
+    :param string key: The pants.ini config key this scratch dir can be overridden with.
+    :param default_name: A name to use instead of the keyname for the scratch dir.
+
+    User's can override the location using the key in pants.ini.
+    """
+    return self._config.get(
+        self._section,
+        key,
+        default=os.path.join(self.scratch_root, default_name or key))

--- a/src/python/twitter/pants/python/resolver.py
+++ b/src/python/twitter/pants/python/resolver.py
@@ -15,6 +15,8 @@ from twitter.common.python.translator import (
     EggTranslator,
     SourceTranslator)
 
+from .python_setup import PythonSetup
+
 from pkg_resources import (
     Environment,
     WorkingSet,
@@ -35,7 +37,8 @@ def fetchers_from_config(config):
 
 
 def crawler_from_config(config, conn_timeout=None):
-  return Crawler(cache=config.get('python-setup', 'download_cache'), conn_timeout=conn_timeout)
+  download_cache = PythonSetup(config).scratch_dir('download_cache', default_name='downloads')
+  return Crawler(cache=download_cache, conn_timeout=conn_timeout)
 
 
 class PantsEnvironment(Environment):
@@ -75,7 +78,7 @@ def resolve_multi(config,
   if not isinstance(interpreter, PythonInterpreter):
     raise TypeError('Expected interpreter to be a PythonInterpreter, got %s' % type(interpreter))
 
-  install_cache = config.get('python-setup', 'install_cache')
+  install_cache = PythonSetup(config).scratch_dir('install_cache', default_name='eggs')
   platforms = get_platforms(platforms or config.getlist('python-setup', 'platforms', ['current']))
   crawler = crawler_from_config(config, conn_timeout=conn_timeout)
   fetchers = fetchers_from_config(config)


### PR DESCRIPTION
This is a result of building a clean, minimal chroot to built Twitter in-house pants.
The change removes some now dead keys from commons pants.ini and inserts
defaults for other keys such that no pants.ini contents at all are needed to build
 a pex from a pip installed pants.

https://rbcommons.com/s/twitter/r/69/
