### PR TITLE
Fixup the ./pants script by grabbing just the md5 value

### DIFF
--- a/build-support/python/libvirtualenv.sh
+++ b/build-support/python/libvirtualenv.sh
@@ -2,7 +2,7 @@ function setup_virtualenv() {
   script="$1"            # 'rbt'
   requirements="$2"      # 'RBTools==0.5.5'
   pip_install_opts="$3"  # '--allow-external RBTools --allow-unverified RBTools'
-  fingerprint=$(echo $script $requirements | openssl md5)
+  fingerprint=$(echo $script $requirements | openssl md5 | cut -d' ' -f2)
 
   HERE=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
   VENV_DIR="$HERE/../${script}.venv"

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Wrapper for self-bootstrapping virtualenv
-set -ex
+set -e
 VIRTUALENV_VERSION=1.11.4
 
 if which python2.7 >/dev/null; then


### PR DESCRIPTION
Discovered ./pants not properly re-using its cache on my linux box.  I suspect this behavior must occur on OSX too - openssl md5 should have uniform behavior here.

RB: https://rbcommons.com/s/twitter/r/113/
