### PR TITLE
Divorce expand_files from CWD.

### DIFF
--- a/src/python/twitter/pants/targets/with_sources.py
+++ b/src/python/twitter/pants/targets/with_sources.py
@@ -47,7 +47,7 @@ class TargetWithSources(Target):
     files = []
 
     def _expand(target):
-      files.extend([os.path.abspath(os.path.join(target.target_base, s))
+      files.extend([os.path.join(get_buildroot(), os.path.join(target.target_base, s))
           for s in (target.sources or [])])
       if include_buildfile:
         files.append(target.address.buildfile.full_path)


### PR DESCRIPTION
Switch from abspath to adjoining the build_root.
This is both safe in prod and in tests that establish
their own build root.

https://rbcommons.com/s/twitter/r/142/
