### PR TITLE
Guard against long ids.

### DIFF
--- a/src/python/twitter/pants/base/BUILD
+++ b/src/python/twitter/pants/base/BUILD
@@ -69,7 +69,8 @@ python_library(
     pants(':hash_utils'),
     pants(':target'),
     pants('src/python/twitter/common/dirutil'),
-    pants('src/python/twitter/common/lang'),
+    pants('src/python/twitter/common/dirutil'),
+    pants('src/python/twitter/pants/fs'),
   ]
 )
 

--- a/src/python/twitter/pants/base/build_invalidator.py
+++ b/src/python/twitter/pants/base/build_invalidator.py
@@ -26,6 +26,7 @@ from twitter.common.dirutil import safe_mkdir
 from twitter.common.lang import Compatibility, Interface
 
 from twitter.pants.base.hash_utils import hash_all
+from twitter.pants.fs import safe_filename
 from twitter.pants.base.target import Target
 
 
@@ -226,7 +227,7 @@ class BuildInvalidator(object):
     return self._sha_file_by_id(cache_key.id)
 
   def _sha_file_by_id(self, id):
-    return os.path.join(self._root, id) + '.hash'
+    return os.path.join(self._root, safe_filename(id, extension='.hash'))
 
   def _write_sha(self, cache_key):
     with open(self._sha_file(cache_key), 'w') as fd:


### PR DESCRIPTION
The BuildInvalidator uses ids that most often come from targets and
these can be lengthy when the targets are synthetic.  If the id > ~250
characters, this will produce a hash filename that's too long for most
common filesystems.  Guard against this with safe_filename and shorten
to a hash iff needed to avoid this.

https://rbcommons.com/s/twitter/r/150/
