### PR TITLE
Respect dep order in the breadth 1st dep walk.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -40,7 +40,6 @@ jar_library(name = 'benchmark-java-allocation-instrumenter-2.1',
 
 jar_library(name = 'zinc',
             dependencies = [
-              jar(org = 'jline', name = 'jline', rev = '1.0'),
               jar(org = 'com.typesafe.zinc', name = 'zinc', rev = '0.3.2-M1')
                 .exclude(org = 'com.martiansoftware', name = 'nailgun-server')
                 .exclude(org = 'org.ensime', name = 'ensime-sbt-cmd')

--- a/src/python/twitter/pants/tasks/ivy_utils.py
+++ b/src/python/twitter/pants/tasks/ivy_utils.py
@@ -26,7 +26,7 @@ import errno
 from collections import namedtuple, defaultdict
 from contextlib import contextmanager
 
-from twitter.common.collections import OrderedSet
+from twitter.common.collections import OrderedDict, OrderedSet
 from twitter.common.dirutil import safe_mkdir, safe_open
 
 from twitter.pants.base.build_environment import get_buildroot
@@ -232,7 +232,7 @@ class IvyUtils(object):
     def is_jardependant(target):
       return target.is_jar or target.is_jvm
 
-    jars = {}
+    jars = OrderedDict()
     excludes = set()
 
     # Support the ivy force concept when we sanely can for internal dep conflicts.


### PR DESCRIPTION
This change led to a zinc error claiming jline was incompatible.
Notably, the custom jline dep in BUILD.tools was now 1st on the
classpath.  It turns out zinc / scala-compiler pulls in a jline
on its own so kill the un-needed jline dep.

https://rbcommons.com/s/twitter/r/156/
