### PR TITLE
Expose the ttl and install_cache properties on CachingObtainer.

### DIFF
--- a/src/python/twitter/common/python/obtainer.py
+++ b/src/python/twitter/common/python/obtainer.py
@@ -122,6 +122,14 @@ class CachingObtainer(Obtainer):
         precedence=self._precedence,
     )
 
+  @property
+  def ttl(self):
+    return self.__ttl
+
+  @property
+  def install_cache(self):
+    return self.__install_cache
+
   def _has_expired_ttl(self, dist):
     now = time.time()
     return now - os.path.getmtime(dist.location) >= self.__ttl


### PR DESCRIPTION
They're "public" anyway, in the sense that they're passed into
**init**(). But this allows the PantsObtainer subclass of CachingObtainer
 to access them in a natural way and use them to initialize the temporary
CachingObtainers it delegates to.
