### PR TITLE
Close the open files before trying to move them

### DIFF
--- a/src/java/com/twitter/common/jar/tool/JarBuilder.java
+++ b/src/java/com/twitter/common/jar/tool/JarBuilder.java
@@ -931,6 +931,9 @@ public class JarBuilder implements Closeable {
           }
           copyJarFiles(writer, jarEntries);
 
+          // Close all open files, the moveFile below might need to copy instead of just rename.
+          closer.close();
+
           // Rename the file (or copy if it can't be renamed)
           target.delete();
           org.apache.commons.io.FileUtils.moveFile(tmp, target);


### PR DESCRIPTION
I tested this with Patrick's suggestion:

First, setup a ramdisk wherever you like:

```
$ hdid -nomount ram://8192000
/dev/disk2
$ newfs_hfs -v "Demo Ramdisk" /dev/disk2
Initialized /dev/rdisk2 as a 4 GB case-insensitive HFS Plus volume
$ mkdir demo_ramdisk
$ mount -t hfs /dev/disk2 /Users/pl/demo_ramdisk
```

Then make that the temp dir for jar-tool:

```
$ git diff
diff --git a/pants.ini b/pants.ini
index 2806fd0..2a6ea66 100644
--- a/pants.ini
+++ b/pants.ini
@@ -264,6 +264,8 @@ jvm_args: ['-Xmx1g', '-XX:MaxPermSize=256m']
 [jar-publish]
 ivy_settings: %(pants_supportdir)s/ivy/ivysettings.xml

+[jar-tool]
+jvm_args: ['-Djava.io.tmpdir=/Users/pl/demo_ramdisk']

 [ide]
 python_source_paths: ['src/python']
```

Then run

`./pants goal bundle src/scala/com/pants/example:jvm-run-example`
