### PR TITLE
Allow properties dict along within a ServiceInstance

### DIFF
--- a/src/python/twitter/common/zookeeper/serverset/endpoint.py
+++ b/src/python/twitter/common/zookeeper/serverset/endpoint.py
@@ -1,16 +1,14 @@
 import json
 from thrift.TSerialization import deserialize as thrift_deserialize
 
-from gen.twitter.thrift.endpoint.ttypes import (
-  Endpoint as ThriftEndpoint,
-  ServiceInstance as ThriftServiceInstance)
-
 try:
   from twitter.common import log
 except ImportError:
   import logging as log
 
 from twitter.common.lang import Compatibility
+
+from gen.twitter.thrift.endpoint.ttypes import (ServiceInstance as ThriftServiceInstance)
 
 
 class Endpoint(object):
@@ -163,7 +161,8 @@ class ServiceInstance(object):
   def pack(cls, service_instance):
     return json.dumps(cls.to_dict(service_instance))
 
-  def __init__(self, service_endpoint, additional_endpoints=None, status='ALIVE', shard=None, properties=None):
+  def __init__(self, service_endpoint, additional_endpoints=None, status='ALIVE', shard=None,
+               properties=None):
     if not isinstance(service_endpoint, Endpoint):
       raise ValueError('Expected service_endpoint to be an Endpoint, got %r' % service_endpoint)
     self._shard = shard

--- a/src/python/twitter/common/zookeeper/serverset/serverset.py
+++ b/src/python/twitter/common/zookeeper/serverset/serverset.py
@@ -82,11 +82,12 @@ class ServerSet(object):
     if on_join or on_leave:
       self._internal_monitor(set(self._members))
 
-  def join(self, endpoint, additional=None, shard=None, callback=None, expire_callback=None):
+  def join(self, endpoint, additional=None, shard=None, properties=None, callback=None, expire_callback=None):
     """
       Given 'endpoint' (twitter.common.zookeeper.serverset.Endpoint) and an
-      optional map 'additional' of string => endpoint (also Endpoint), and an
-      optional shard id, create a ServiceInstance and join it into this ServerSet.
+      optional map 'additional' of string => endpoint (also Endpoint), an
+      optional shard id, and an optional properties dictionary, create a
+      ServiceInstance and join it into this ServerSet.
 
       If 'callback' is provided, the join will be done asynchronously and
       'callback' will be called with the Membership object associated with
@@ -97,7 +98,7 @@ class ServerSet(object):
       If 'expire_callback' is provided, it will be called if the membership
       is severed for any reason such as session expiration or malice.
     """
-    service_instance = ServiceInstance.pack(ServiceInstance(endpoint, additional, shard=shard))
+    service_instance = ServiceInstance.pack(ServiceInstance(endpoint, additional, shard=shard, properties=properties))
     return self._group.join(service_instance, callback=callback, expire_callback=expire_callback)
 
   def cancel(self, membership, callback=None):

--- a/src/python/twitter/common/zookeeper/serverset/serverset.py
+++ b/src/python/twitter/common/zookeeper/serverset/serverset.py
@@ -82,7 +82,8 @@ class ServerSet(object):
     if on_join or on_leave:
       self._internal_monitor(set(self._members))
 
-  def join(self, endpoint, additional=None, shard=None, properties=None, callback=None, expire_callback=None):
+  def join(self, endpoint, additional=None, shard=None, properties=None, callback=None,
+           expire_callback=None):
     """
       Given 'endpoint' (twitter.common.zookeeper.serverset.Endpoint) and an
       optional map 'additional' of string => endpoint (also Endpoint), an
@@ -98,7 +99,8 @@ class ServerSet(object):
       If 'expire_callback' is provided, it will be called if the membership
       is severed for any reason such as session expiration or malice.
     """
-    service_instance = ServiceInstance.pack(ServiceInstance(endpoint, additional, shard=shard, properties=properties))
+    service_instance = ServiceInstance.pack(ServiceInstance(endpoint, additional, shard=shard,
+                                                            properties=properties))
     return self._group.join(service_instance, callback=callback, expire_callback=expire_callback)
 
   def cancel(self, membership, callback=None):

--- a/tests/python/twitter/common/zookeeper/serverset/test_base.py
+++ b/tests/python/twitter/common/zookeeper/serverset/test_base.py
@@ -68,8 +68,10 @@ class ServerSetTestBase(object):
     p = {'announced_by': 'foo'}
     ss1.join(self.INSTANCE1, shard=0)
     ss2.join(self.INSTANCE2, shard=1, properties=p)
-    assert list(ss1) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1, properties=p)]
-    assert list(ss2) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1, properties=p)]
+    assert list(ss1) == [ServiceInstance(self.INSTANCE1, shard=0),
+                         ServiceInstance(self.INSTANCE2, shard=1, properties=p)]
+    assert list(ss2) == [ServiceInstance(self.INSTANCE1, shard=0),
+                         ServiceInstance(self.INSTANCE2, shard=1, properties=p)]
 
   def test_canceled_join_long_time(self):
     zk = self.make_zk(self._server.ensemble)

--- a/tests/python/twitter/common/zookeeper/serverset/test_base.py
+++ b/tests/python/twitter/common/zookeeper/serverset/test_base.py
@@ -65,10 +65,11 @@ class ServerSetTestBase(object):
   def test_shard_id_registers(self):
     ss1 = ServerSet(self.make_zk(self._server.ensemble), self.SERVICE_PATH)
     ss2 = ServerSet(self.make_zk(self._server.ensemble), self.SERVICE_PATH)
+    p = {'announced_by': 'foo'}
     ss1.join(self.INSTANCE1, shard=0)
-    ss2.join(self.INSTANCE2, shard=1)
-    assert list(ss1) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1)]
-    assert list(ss2) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1)]
+    ss2.join(self.INSTANCE2, shard=1, properties=p)
+    assert list(ss1) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1, properties=p)]
+    assert list(ss2) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1, properties=p)]
 
   def test_canceled_join_long_time(self):
     zk = self.make_zk(self._server.ensemble)


### PR DESCRIPTION
When joining a ServerSet, it can be handy to attach some extra data to
the published ServiceInstance (i.e.: debugging info, service version,
etc.). This is expressed in the form of a <str, str> properties dict.

This only takes effect when reading/writing JSON (for now).

Signed-off-by: Raul Gutierrez S rgs@twitter.com
