### PR TITLE
Loosen up t.c.pants constraints.

### DIFF
--- a/pants-plugins/3rdparty/BUILD
+++ b/pants-plugins/3rdparty/BUILD
@@ -19,6 +19,6 @@ python_requirement_library(
   requirements=[
     # TODO(John Sirois): centralize this requirement for use by the wrapper script and the plugins
     # themselves.
-    python_requirement('pantsbuild.pants==0.0.17')
+    python_requirement('pantsbuild.pants>=0.0.17,<0.1.0')
   ]
 )

--- a/pants-plugins/src/python/twitter/common/pants/BUILD
+++ b/pants-plugins/src/python/twitter/common/pants/BUILD
@@ -21,7 +21,7 @@ python_library(
   ],
   provides = setup_py(
     name = 'twitter.common.pants',
-    version = '0.3.2',
+    version = '0.3.3',
     description = 'twitter.common plugins for the pants build system.',
     url = 'https://github.com/twitter/commons',
     license = 'Apache License, Version 2.0',


### PR DESCRIPTION
The twitter.common.pants plugins were pinned hard to
pantsbuild.pants==0.0.17 limiting the context they could be used in.

Expand the scope of supported pants releases up to 0.1.0 even though
this is likely to permissive.  The pantsbuild.pants distributions will
probably continue to break various APIs until we hit 0.1.0 and being
more permissive and then fixing the low bound on the range when the
plugins break seems about the best we can do.

This also preps an sdist release with a version bump.

https://rbcommons.com/s/twitter/r/712/
