### PR TITLE
Add to Application class a method to set the usage message automatically.

### DIFF
--- a/src/python/twitter/common/app/application.py
+++ b/src/python/twitter/common/app/application.py
@@ -630,6 +630,26 @@ class Application(object):
     """
     self._usage = usage
 
+  def set_usage_based_on_commands(self):
+    """
+      Sets the usage message automatically, to show the available commands.
+    """
+    self.set_usage(
+      'Please run with one of the following commands:\n' +
+      '\n'.join(['  %-22s%s' % (command, self._set_string_margin(docstring or '', 0, 24))
+                 for (command, docstring) in self.get_commands_and_docstrings()])
+    )
+
+  @staticmethod
+  def _set_string_margin(s, first_line_indentation, other_lines_indentation):
+    """
+      Given a multi-line string, resets the indentation to the given number of spaces.
+    """
+    lines = s.strip().splitlines()
+    lines = ([' ' * first_line_indentation  + line.strip() for line in lines[:1]] +
+             [' ' * other_lines_indentation + line.strip() for line in lines[1:]])
+    return '\n'.join(lines)
+
   def error(self, message):
     """
       Print the application help message, an error message, then exit.


### PR DESCRIPTION
The usage message will show the available commands and their docstrings.

Example auto-generated usage message:

```
Usage: Please run with one of the following commands:
  cron_once             Execute the cron once.
                        The cron fetches from git, does validation, and updates ZooKeeper.
  debugger              Launch into the debugger, giving you a Python REPL with access to Git and ZooKeeper.
  cron_continuously     Execute the cron every CRON_INTERVAL_SECONDS seconds.
                        If there's an exception, the process will fail. Otherwise, the process will run forever.
                        The cron fetches from git, does validation, and updates ZooKeeper.
  server                Run as the server.
                        The server is mainly used for monitoring and diagnostics.
                        Takes one argument: The port on which to accept requests.

Options:
  -h, --help, --short-help
                        show this help message and exit.
  --long-help           show options from all registered modules, not just the
                        __main__ module.
```
