### PR TITLE
Remove unnecessary atexit handler for tearing down ssh processes

### DIFF
--- a/src/python/twitter/common/net/tunnel.py
+++ b/src/python/twitter/common/net/tunnel.py
@@ -129,6 +129,7 @@ class TunnelHelper(object):
     if not cls.wait_for_accept(tunnel_port, ssh_popen, timeout):
       raise cls.TunnelError('Could not establish tunnel to %s via %s' % (remote_host, tunnel_host))
     cls.log('session established')
+    atexit.register(safe_kill, ssh_popen)
     return 'localhost', tunnel_port
 
   @classmethod
@@ -146,6 +147,7 @@ class TunnelHelper(object):
     if not cls.wait_for_accept(proxy_port, ssh_popen, timeout):
       raise cls.TunnelError('Could not establish proxy via %s' % proxy_host)
     cls.log('session established')
+    atexit.register(safe_kill, ssh_popen)
     return 'localhost', proxy_port
 
   @classmethod
@@ -156,11 +158,3 @@ class TunnelHelper(object):
     _, po = cls.TUNNELS.pop((remote_host, remote_port), (None, None))
     if po:
       safe_kill(po)
-
-
-@atexit.register
-def _cleanup():
-  for _, po in TunnelHelper.TUNNELS.values():
-    safe_kill(po)
-  for _, po in TunnelHelper.PROXIES.values():
-    safe_kill(po)

--- a/tests/python/twitter/common/net/BUILD
+++ b/tests/python/twitter/common/net/BUILD
@@ -18,6 +18,7 @@ python_test_suite(
   name = 'all',
   dependencies = [
     ':socks',
+    ':tunnel',
   ]
 )
 
@@ -27,5 +28,13 @@ python_tests(
   dependencies = [
     'src/python/twitter/common/net:socks',
     '3rdparty/python:mox'
+  ],
+)
+
+python_tests(
+  name = 'tunnel',
+  sources = ['test_tunnel.py'],
+  dependencies = [
+    'src/python/twitter/common/net:tunnel'
   ],
 )

--- a/tests/python/twitter/common/net/test_tunnel.py
+++ b/tests/python/twitter/common/net/test_tunnel.py
@@ -1,0 +1,6 @@
+from twitter.common.net.tunnel import TunnelHelper
+
+# This test file ensures there are no SyntaxErrors in the tunnel module.
+
+def test_nothing():
+  assert True


### PR DESCRIPTION
I have noticed that the TunnelHelper class reference in the `_cleanup` function can be `None` when executed. This causes an exception and therefore fails to kill the opened ssh processes. This patch changes the approach taken to avoid the `_cleanup` function entirely and still achieve the same results.
