### PR TITLE
Improve commons CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: python
-
-python:
-  - "2.6"
-  - "2.7"
+language: java
 
 jdk:
   - openjdk6
@@ -11,9 +7,4 @@ jdk:
 script: |
   java -version
   ./build-support/bin/ci.sh -d
-
-notifications:
-  email:
-    - john.sirois@gmail.com
-    - yasumoto7@gmail.com
 

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -5,8 +5,6 @@ VIRTUALENV_VERSION=1.11.4
 
 if which python2.7 >/dev/null; then
   PY=`which python2.7`
-elif which python2.6 >/dev/null; then
-  PY=`which python2.6`
 else
   echo 'No python interpreter found on the path.  Python will not work!' 1>&2
   exit 1


### PR DESCRIPTION
Previously we were building under python2.6 and 2.7 even
though Twitter has since moved on to drop support for python2.6.

This change instead fixes the build to python2.7 and leverages
that pinning to pivot the matrix axis to jvms and exercise 1.6 & 1.7.

This change also removes the custom notification and falls back to the
default of emailing the submitter and comitter.  The idea here is
to give responsible contributors the feedback they need to roll back
or fix breaks instead of bottlenecking on 2 potentially unrelated
people.

https://rbcommons.com/s/twitter/r/1472/
