### PR TITLE
Use Travis CIs new container based builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,11 @@
 /bin/
 dot.twkeys
 build/
-build-support/*.pex
-build-support/*.venv
-build-support/virtualenv-*
-build-support/phab/
+/build-support/*.pex
+/build-support/*.venv
+/build-support/virtualenv-*
+/build-support/virtualenv.dist/
+/build-support/phab/
 codegen/classes/
 dist/
 htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
+# Enables support for a docker container-based build
+# which should provide faster startup times and beefier
+# "machines". This is also required in order to use the
+# cache configured below.
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.pants.d
+    - $HOME/.ivy2
+    - build-support/pants.venv
+    - build-support/virtualenv.dist
+
 language: java
 
 jdk:

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -81,8 +81,7 @@ fi
 if [[ "${skip_java:-false}" == "false" ]]; then
   banner "Running jvm tests"
   (
-    ./pants goal test {src,tests}/java/com/twitter/common:: $daemons -x ${INTERPRETER_ARGS[@]} \
-      --test-junit-per-test-timer --test-junit-parallel-threads=1 && \
+    ./pants goal test {src,tests}/java/com/twitter/common:: $daemons -x ${INTERPRETER_ARGS[@]} && \
     ./pants goal test {src,tests}/scala/com/twitter/common:: $daemons -x ${INTERPRETER_ARGS[@]}
   ) || die "Jvm test failure."
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -81,7 +81,8 @@ fi
 if [[ "${skip_java:-false}" == "false" ]]; then
   banner "Running jvm tests"
   (
-    ./pants goal test {src,tests}/java/com/twitter/common:: $daemons -x ${INTERPRETER_ARGS[@]} && \
+    ./pants goal test {src,tests}/java/com/twitter/common:: $daemons -x ${INTERPRETER_ARGS[@]} \
+      --test-junit-per-test-timer --test-junit-parallel-threads=1 && \
     ./pants goal test {src,tests}/scala/com/twitter/common:: $daemons -x ${INTERPRETER_ARGS[@]}
   ) || die "Jvm test failure."
 fi

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -13,13 +13,15 @@ fi
 echo "Using $PY" >&2
 
 HERE=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
-if ! [ -f "$HERE/virtualenv-$VIRTUALENV_VERSION/BOOTSTRAPPED" ]; then
+if ! [ -f "$HERE/virtualenv.dist/BOOTSTRAPPED-$VIRTUALENV_VERSION" ]; then
   pushd "$HERE"
   curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-$VIRTUALENV_VERSION.tar.gz
   tar zxvf virtualenv-$VIRTUALENV_VERSION.tar.gz
   # TODO(ksweeney): Checksum
-  touch virtualenv-$VIRTUALENV_VERSION/BOOTSTRAPPED  # 2PC
+  touch virtualenv-$VIRTUALENV_VERSION/BOOTSTRAPPED-$VIRTUALENV_VERSION  # 2PC
+  rm -rf virtualenv.dist
+  mv virtualenv-$VIRTUALENV_VERSION virtualenv.dist
   popd
 fi
 
-exec "$PY" "$HERE/virtualenv-$VIRTUALENV_VERSION/virtualenv.py" "$@"
+exec "$PY" "$HERE/virtualenv.dist/virtualenv.py" "$@"


### PR DESCRIPTION
The announcement is here:
  http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure
The specs here:
  http://docs.travis-ci.com/user/workers/container-based-infrastructure
  http://docs.travis-ci.com/user/caching/#Fetching-and-storing-caches

This also turns on caching for ~/.pants.d, ~/.ivy2
and the current pants version bootstraped in
build-support.  To make virtualenv caching work, updates
the virtualenv bootstrap script to use a stable directory name
across virtualenv versions.
