### PR TITLE
Windowed.getCurrentIndex() changed int to long

### DIFF
--- a/src/java/com/twitter/common/stats/Windowed.java
+++ b/src/java/com/twitter/common/stats/Windowed.java
@@ -85,9 +85,9 @@ public abstract class Windowed<T> {
    * Return the index of the latest Histogram.
    * You have to modulo it with buffer.length before accessing the array with this number.
    */
-  protected int getCurrentIndex() {
+  protected long getCurrentIndex() {
     long now = clock.nowMillis();
-    return (int) (now / sliceDuration);
+    return (now / sliceDuration);
   }
 
   /**


### PR DESCRIPTION
When using e.g. WindowedStatistics with a time window/number of slice combination that results in a sliceDuration of less than 662 ms(currently) index calculation in Windowed.getCurrentIndex() fails because System.currentTimeMillis()/662 > Integer.MAX_VALUE and casting it to int produces unpredictable results.

"Best case" is that getCurrentIndex() returns a negative value (as happened to me), causing an ArrayIndexOutOfBoundsException because the whole code in sync() is skipped and index will remain at the initial value of -1.

This is Issue #355 .
