### PR TITLE
Upgrade to jar-tool 0.1.10.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -109,8 +109,5 @@ make_lib('org.scala-lang', 'scala-compiler', '2.9.3', lib_name='scala-repl',
 
 
 # JarTask
-# TODO(John Sirois): Upgrade past 0.1.9 when a 0.1.10+ version of the tool is published with
-# java 1.6 version classfiles.  The 0.1.8 and 0.1.9 jars contain java 1.7 classfiles.
-# see: https://github.com/twitter/commons/issues/361
-make_lib('com.twitter.common', 'jar-tool', '0.1.7')
+make_lib('com.twitter.common', 'jar-tool', '0.1.10')
 

--- a/pants.ini
+++ b/pants.ini
@@ -18,10 +18,7 @@ pythonpath: [
     "%(buildroot)s/pants-plugins/src/python",
   ]
 
-# TODO(John Sirois): Revert to 100 when jar-tool is upgaded past 0.1.9 - currently this just
-# avoids passing the jar-tool an @arg-file arg which 0.1.7 does not understand.
-# see: https://github.com/twitter/commons/issues/361
-max_subprocess_args: 1000
+max_subprocess_args: 100
 
 checkstyle_suppression_files = [
     '%(pants_supportdir)s/commons/checkstyle/checkstyle_suppressions.xml'


### PR DESCRIPTION
This jar-tool release is compatible with both pants 0.0.31+ as well as
java 6 runtimes.