### PR TITLE
Switch to bintray for pants tools maven artifacts.

### DIFF
--- a/build-support/commons/ivy/ivysettings.xml
+++ b/build-support/commons/ivy/ivysettings.xml
@@ -27,7 +27,8 @@ limitations under the License.
                root="http://repo1.maven.org/maven2/"/>
 
       <!-- This is just for jvm tools used by Pants and not yet published to maven central.
-           Kill once they are published to maven central. -->
+           TODO(John Sirois): Kill once they are published to maven central.
+           See: http://github.com/twitter/commons/issues/370 -->
       <ibiblio name="pantsbuild-maven-repo"
                m2compatible="true"
                usepoms="true"

--- a/build-support/commons/ivy/ivysettings.xml
+++ b/build-support/commons/ivy/ivysettings.xml
@@ -26,16 +26,18 @@ limitations under the License.
                usepoms="true"
                root="http://repo1.maven.org/maven2/"/>
 
-      <ibiblio name="maven.twttr.com-maven"
+      <!-- This is just for jvm tools used by Pants and not yet published to maven central.
+           Kill once they are published to maven central. -->
+      <ibiblio name="pantsbuild-maven-repo"
+               m2compatible="true"
+               usepoms="true"
+               root="https://dl.bintray.com/pantsbuild/maven/"/>
+
+       <!-- Used only for com.twitter.common#metrics-data-sample -->
+       <ibiblio name="maven.twttr.com-maven"
                m2compatible="true"
                usepoms="true"
                root="http://maven.twttr.com/"/>
-
-      <!--  This is just for spy#spymemcached;2.8.1 -->
-      <ibiblio name="jboss-public"
-               m2compatible="true"
-               usepoms="true"
-               root="http://repository.jboss.org/nexus/content/groups/public/"/>
     </chain>
   </macrodef>
 </ivysettings>


### PR DESCRIPTION
Also kill the now-unused jboss repo and comment why maven.twttr.com is
still needed as a repo.