### PR TITLE
Drop the openjdk 6 CI shard.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ cache:
 language: java
 
 jdk:
-  - openjdk6
   - openjdk7
 
 script: |


### PR DESCRIPTION
Twitter has moved on to ony support java 7 as a minimum internally and
so fighting CI failures under java 6 is a losing battle going forward.

https://rbcommons.com/s/twitter/r/2030/