### PR TITLE
Annotation based skipping of fields in ObjectSizeCalculator

### DIFF
--- a/src/java/com/twitter/common/objectsize/ObjectSizeCalculator.java
+++ b/src/java/com/twitter/common/objectsize/ObjectSizeCalculator.java
@@ -28,6 +28,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import com.twitter.common.objectsize.ObjectSizeIgnoreField;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
@@ -286,12 +288,17 @@ public class ObjectSizeCalculator {
         if (Modifier.isStatic(f.getModifiers())) {
           continue;
         }
+	boolean ignoreSubtree = f.getAnnotation(ObjectSizeIgnoreField.class) != null;
+
         final Class<?> type = f.getType();
         if (type.isPrimitive()) {
           fieldsSize += getPrimitiveFieldSize(type);
         } else {
-          f.setAccessible(true);
-          referenceFields.add(f);
+          if (!ignoreSubtree)
+          {
+            f.setAccessible(true);
+            referenceFields.add(f);
+          }
           fieldsSize += referenceSize;
         }
       }

--- a/src/java/com/twitter/common/objectsize/ObjectSizeIgnoreField.java
+++ b/src/java/com/twitter/common/objectsize/ObjectSizeIgnoreField.java
@@ -23,6 +23,11 @@ import java.lang.annotation.*;
  * for references to other objects not of interest. For example, references to objects that are from a in-heap Cache
  * may be not of interest, to avoid duplicated counting when one is doing an extra measurement for that Cache.
  * <p>
+ * Using this annotation REQUIRES it to be available in the runtime classpath, as it uses RetentionPolicy.RUNTIME.
+ * When usage of this annotation is not feasible, an own annotation can be used. It must be set with
+ * ObjectSizeCalculator#setIgnoreFieldAnnotation(Class<? extends Annotation> annotation). 
+ * 
+ * <p>
  * References are counted with the size of a reference in the memory model. Primitive types cannot be ignored,
  * they are always counted.
  *

--- a/src/java/com/twitter/common/objectsize/ObjectSizeIgnoreField.java
+++ b/src/java/com/twitter/common/objectsize/ObjectSizeIgnoreField.java
@@ -37,5 +37,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ObjectSizeIgnoreField
 {
+	String reason() default "";
 }
 

--- a/src/java/com/twitter/common/objectsize/ObjectSizeIgnoreField.java
+++ b/src/java/com/twitter/common/objectsize/ObjectSizeIgnoreField.java
@@ -1,0 +1,36 @@
+// =================================================================================================
+// Copyright 2015 trivago GmbH
+// -------------------------------------------------------------------------------------------------
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this work except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file, or at:
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =================================================================================================
+
+package com.twitter.common.objectsize;
+
+import java.lang.annotation.*;
+
+/**
+ * A flag annotation to tag fields which should not get counted in the ObjectSizeCalculator. This is useful
+ * for references to other objects not of interest. For example, references to objects that are from a in-heap Cache
+ * may be not of interest, to avoid duplicated counting when one is doing an extra measurement for that Cache.
+ * <p>
+ * References are counted with the size of a reference in the memory model. Primitive types cannot be ignored,
+ * they are always counted.
+ *
+ * @author Christian Esken, trivago GmbH
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ObjectSizeIgnoreField
+{
+}
+


### PR DESCRIPTION
This change adds annotation support to ObjectSizeCalculator. The whole object tree below a field annotated with ObjectSizeIgnoreField is ignored. 
## When to use

This is useful if there are references to other objects not of interest. For example, objects from a DB may be cached in the heap. If one measures that Cache separately, there may be no need to measure references from other places to those objects (again). Also, references to a classloader (directly or indirectly via a Thread instance) can end up with measuring the whole heap.
## Technical details

Ignoring means to ignore the whole object subtree _below the field_. The field itself is counted normally: _References_ are counted with the size of a reference in the memory model. As _primitive types_ are never shared, they are not ignored and thus always counted.
The annotation class can be freely chosen via setIgnoreFieldAnnotation(), to avoid hard runtime dependencies to ObjectSizeCalculator  or ObjectSizeIgnoreField.
