### PR TITLE
Python linter: improvements to git intergration

### DIFF
--- a/src/python/twitter/checkstyle/checker.py
+++ b/src/python/twitter/checkstyle/checker.py
@@ -25,9 +25,6 @@ from .iterators import git_iterator, path_iterator
 from .plugins import list_plugins
 
 
-DEFAULT_BRANCH = 'master'
-
-
 app.add_option(
   '-p',
   action='append',
@@ -60,7 +57,7 @@ app.add_option(
   default=None,
   dest='diff',
   help='If specified, only checkstyle against the diff of the supplied branch, e.g. --diff=master.'
-    ' Defaults to master if no paths are specified.')
+    ' Defaults to $(git merge-base master HEAD) if no paths are specified.')
 
 
 app.add_option(
@@ -138,13 +135,11 @@ def proxy_main():
         plugins_map.pop(plugin, None)
       plugins = list(plugins_map.values())
 
-    if not args and options.diff is None:
-      options.diff = DEFAULT_BRANCH
-
-    if options.diff:
-      iterator = git_iterator(args, options)
-    else:
+    if args and not options.diff:
       iterator = path_iterator(args, options)
+    else:
+      # No path, use git to find what changed.
+      iterator = git_iterator(args, options)
 
     severity = Nit.COMMENT
     for number, name in Nit.SEVERITY.items():

--- a/src/python/twitter/checkstyle/iterators.py
+++ b/src/python/twitter/checkstyle/iterators.py
@@ -84,7 +84,7 @@ def tuple_from_diff(diff):
     From GitPython:
 
     It contains two sides a and b of the diff, members are prefixed with
-    "a" and "b" respectively to inidcate that.
+    "a" and "b" respectively to indicate that.
 
     Diffs keep information about the changed blob objects, the file mode, renames,
     deletions and new files.
@@ -117,6 +117,6 @@ def git_iterator(args, options):
     raise ValueError('Git has not been enabled for this checkstyle library!')
 
   repo = Repo()
-  diff_commit = repo.rev_parse(options.diff or 'master')
+  diff_commit = repo.rev_parse(options.diff or repo.git.merge_base('master', 'HEAD'))
   for filename, line_filter in filter(None, map(tuple_from_diff, diff_commit.diff(None))):
-    yield filename, line_filter
+    yield os.path.join(repo.working_tree_dir, filename), line_filter

--- a/tests/python/twitter/checkstyle/test_git_iterators.py
+++ b/tests/python/twitter/checkstyle/test_git_iterators.py
@@ -52,15 +52,25 @@ def test_py_changed_in_branch(tmpdir, repo):
   repo.index.commit("modify a python file in another branch")
   repo.heads.feature_branch.checkout()
 
-  assert [f[0] for f in git_iterator(None, Options(other_branch))] == [python_filename]
+  assert [f[0] for f in git_iterator(None, Options(other_branch))] == [
+      tmpdir.join(python_filename).strpath]
 
 
 def test_py_file_changed(tmpdir, repo):
+  # First create a commit on master. Since we diff against the merge-base to master
+  # by default, it shouldn't be in the diff.
+  repo.heads.master.checkout()
+  python_filename_on_master = 'some-python-file.py'
+  tmpdir.join('some-python-file.py').write('some python in master')
+  repo.index.add([python_filename_on_master])
+  repo.index.commit("commit on master")
+
+  repo.heads.feature_branch.checkout()
   tmpdir.join(python_filename).write('some python to check')
   repo.index.add([python_filename])
   repo.index.commit("modify a python file")
 
-  assert [f[0] for f in git_iterator(None, Options())] == [python_filename]
+  assert [f[0] for f in git_iterator(None, Options())] == [tmpdir.join(python_filename).strpath]
 
 
 def test_py_file_added(tmpdir, repo):
@@ -70,7 +80,7 @@ def test_py_file_added(tmpdir, repo):
   repo.index.add([new_python_filename])
   repo.index.commit("add a python file")
 
-  assert [f[0] for f in git_iterator(None, Options())] == [new_python_filename]
+  assert [f[0] for f in git_iterator(None, Options())] == [tmpdir.join(new_python_filename).strpath]
 
 
 def test_py_file_renamed(tmpdir, repo):
@@ -80,4 +90,4 @@ def test_py_file_renamed(tmpdir, repo):
   repo.index.add([new_python_filename])
   repo.index.commit("rename a python file")
 
-  assert [f[0] for f in git_iterator(None, Options())] == [new_python_filename]
+  assert [f[0] for f in git_iterator(None, Options())] == [tmpdir.join(new_python_filename).strpath]


### PR DESCRIPTION
- Diff against merge-base master, rather than master, by default

- Fix issue when the linter is not running from the repo top-level
  directory.