### PR TITLE
Avoid ivy cache thrash due to ivydata updates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,20 @@
 # cache configured below.
 sudo: false
 
+before_cache:
+    # The `ivydata-*.properties` & root level `*.{properties,xml}` files'
+    # effect on resolution time is in the noise, but they are
+    # re-timestamped in internal comments and fields on each run and this
+    # leads to travis-ci cache thrash.  Kill these files before the cache
+    # check to avoid un-needed cache re-packing and re-upload (a ~100s
+    # operation).
+  - find $HOME/.ivy2/twitter-commons -type f -name "ivydata-*.properties" -print -delete
+  - rm -fv $HOME/.ivy2/twitter-commons/*.{css,properties,xml,xsl}
+
 cache:
   directories:
     - $HOME/.cache/pants
-    - $HOME/.ivy2
+    - $HOME/.ivy2/twitter-commons
     - build-support/pants.venv
     - build-support/virtualenv.dist
 


### PR DESCRIPTION
The `ivydata-*.properties` and root-level `*.{properties,xml}` files'
effect on resolution time is in the noise, but they are re-timestamped
in internal comments and fields by ivy on each run and this leads to
cache thrash in travis-ci. Kill these files before the cache check to
avoid un-needed cache re-packing and re-upload which is a ~90s
operation that occurs at the end of our CI run.

https://rbcommons.com/s/twitter/r/2359/