### PR TITLE
Upgrade to pantsbuild.pants 0.0.33.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -42,11 +42,22 @@ make_lib('xalan', 'xalan', '2.7.1')
 
 # JavaCompile
 make_lib('org.pantsbuild', 'jmake', '1.3.8-10')
-make_lib('com.twitter.common.tools', 'java-compiler', '0.0.17')
+make_lib('org.pantsbuild.tools.compiler', 'java-compiler', '0.0.1')
 
 
 # ScalaCompile
-make_lib('com.typesafe.zinc', 'zinc', '0.3.7')
+make_lib('org.pantsbuild', 'zinc', '1.0.6')
+
+# We just want the single compiler-interface and sbt-interface jars and not their deps on
+# scala-lang.
+jar_library(
+  name='compiler-interface',
+  jars=[
+    jar('com.typesafe.sbt', 'compiler-interface', '0.13.8', classifier='sources', intransitive=True)
+  ]
+)
+make_lib('com.typesafe.sbt', 'sbt-interface', '0.13.8', intransitive=True)
+
 jar_library(name='scala-compiler',
   dependencies=[
     '3rdparty/jvm/org/scala-lang:scala-compiler'
@@ -73,12 +84,7 @@ make_lib('org.scalastyle', 'scalastyle_2.9.3', '0.3.2', lib_name='scalastyle')
 
 
 # JunitRun
-make_lib('com.twitter.common', name='junit-runner', rev='0.0.41', lib_name='junit',
-  deps=[
-    '3rdparty/jvm/junit',
-    '3rdparty/jvm/org/hamcrest:hamcrest-core',
-  ]
-)
+make_lib('org.pantsbuild', 'junit-runner', '0.0.5', lib_name='junit')
 make_lib('emma', 'emma', '2.1.5320')
 
 
@@ -101,8 +107,9 @@ make_lib('org.scala-lang', 'scala-compiler', '2.9.3', lib_name='scala-repl',
 
 
 # JarTask
-# TODO(John Sirois): Upgrade past 0.1.9 when a 0.1.10+ version of the tool is published with
-# java 1.6 version classfiles.  The 0.1.8 and 0.1.9 jars contain java 1.7 classfiles.
-# see: https://github.com/twitter/commons/issues/361
-make_lib('com.twitter.common', 'jar-tool', '0.1.7')
+make_lib('org.pantsbuild', 'jar-tool', '0.0.5')
+
+
+# Tool Auto-shading
+make_lib('org.pantsbuild.jarjar', 'jarjar', '1.5')
 

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -111,9 +111,8 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     # TODO(John Sirois): We clean-all here to work-around args resource mapper issues finding leftover
     # entries from args tests in the jvm tests above, kill the clean-all once the resource mapper bug
     # is identified and fixed.
-    PANTS_PYTHON_TEST_FAILSOFT=1 \
-      ./pants --timeout=5 ${INTERPRETER_ARGS[@]} clean-all test.pytest --no-fast \
-        tests/python/twitter/common:all
+    ./pants --timeout=5 ${INTERPRETER_ARGS[@]} clean-all test.pytest --fail-slow --no-fast \
+      tests/python/twitter/common:all
   ) || die "Python test failure"
 fi
 

--- a/build-support/commons/ivy/ivysettings.xml
+++ b/build-support/commons/ivy/ivysettings.xml
@@ -26,14 +26,6 @@ limitations under the License.
                usepoms="true"
                root="http://repo1.maven.org/maven2/"/>
 
-      <!-- This is just for jvm tools used by Pants and not yet published to maven central.
-           TODO(John Sirois): Kill once they are published to maven central.
-           See: http://github.com/twitter/commons/issues/370 -->
-      <ibiblio name="pantsbuild-maven-repo"
-               m2compatible="true"
-               usepoms="true"
-               root="https://dl.bintray.com/pantsbuild/maven/"/>
-
        <!-- Used only for com.twitter.common#metrics-data-sample -->
        <ibiblio name="maven.twttr.com-maven"
                m2compatible="true"

--- a/pants
+++ b/pants
@@ -17,7 +17,7 @@
 
 source build-support/python/libvirtualenv.sh
 
-PANTS_VERSION=0.0.32
+PANTS_VERSION=0.0.33
 
 PANTS_PACKAGES=(
   pantsbuild.pants==${PANTS_VERSION}

--- a/pants.ini
+++ b/pants.ini
@@ -18,6 +18,13 @@ pythonpath: [
     "%(buildroot)s/pants-plugins/src/python",
   ]
 
+backend_packages: [
+    'pants.contrib.scrooge',
+    'twitter.common.pants.jvm.args',
+    'twitter.common.pants.jvm.extras',
+    'twitter.common.pants.python.commons',
+  ]
+
 # TODO(John Sirois): Revert to 100 when jar-tool is upgaded past 0.1.9 - currently this just
 # avoids passing the jar-tool an @arg-file arg which 0.1.7 does not understand.
 # see: https://github.com/twitter/commons/issues/361
@@ -31,9 +38,6 @@ debug_port: 5005
 
 outdir: %(pants_distdir)s
 
-read_artifact_caches: []
-write_artifact_caches: []
-
 ; Mixed into all cache keys. Bump this to invalidate all existing artifacts.
 ; Note: If you want to experiment with this locally without affecting artifacts
 ; read by all, change it to some other string, e.g., <number>-<your username>.
@@ -45,6 +49,16 @@ jvm_options: ['-Xmx1g', '-XX:MaxPermSize=256m']
 python_source_paths: ['src/python']
 python_test_paths: ['tests/python']
 python_lib_paths: ['3rdparty/python']
+
+
+local_artifact_cache = %(pants_bootstrapdir)s/artifact_cache
+
+
+[bootstrap]
+# The just-in-time tool shading performed by jvm tool bootstrapping is very expensive, so we turn
+# on artifact caching for it that can survive clean-all.
+read_artifact_caches = ["%(local_artifact_cache)s"]
+write_artifact_caches = ["%(local_artifact_cache)s"]
 
 
 [goals]
@@ -203,11 +217,3 @@ repos: [
 
 indexes: ['https://pypi.python.org/simple/']
 
-
-[backends]
-packages: [
-    'pants.contrib.scrooge',
-    'twitter.common.pants.jvm.args',
-    'twitter.common.pants.jvm.extras',
-    'twitter.common.pants.python.commons',
-  ]

--- a/pants.ini
+++ b/pants.ini
@@ -25,10 +25,7 @@ backend_packages: [
     'twitter.common.pants.python.commons',
   ]
 
-# TODO(John Sirois): Revert to 100 when jar-tool is upgaded past 0.1.9 - currently this just
-# avoids passing the jar-tool an @arg-file arg which 0.1.7 does not understand.
-# see: https://github.com/twitter/commons/issues/361
-max_subprocess_args: 1000
+max_subprocess_args: 100
 
 checkstyle_suppression_files = [
     '%(pants_supportdir)s/commons/checkstyle/checkstyle_suppressions.xml'

--- a/pants.ini
+++ b/pants.ini
@@ -8,10 +8,6 @@
 ;   pants_workdir: the scratch space used to for live builds in this repo
 
 [DEFAULT]
-pants_support_baseurls = [
-    "https://dl.bintray.com/pantsbuild/bin/build-support"
-  ]
-pants_support_fetch_timeout_secs: 30
 
 # Enable our own custom loose-source plugins.
 pythonpath: [
@@ -25,15 +21,9 @@ backend_packages: [
     'twitter.common.pants.python.commons',
   ]
 
-max_subprocess_args: 100
-
 checkstyle_suppression_files = [
     '%(pants_supportdir)s/commons/checkstyle/checkstyle_suppressions.xml'
   ]
-
-debug_port: 5005
-
-outdir: %(pants_distdir)s
 
 ; Mixed into all cache keys. Bump this to invalidate all existing artifacts.
 ; Note: If you want to experiment with this locally without affecting artifacts
@@ -46,7 +36,6 @@ jvm_options: ['-Xmx1g', '-XX:MaxPermSize=256m']
 python_source_paths: ['src/python']
 python_test_paths: ['tests/python']
 python_lib_paths: ['3rdparty/python']
-
 
 local_artifact_cache = %(pants_bootstrapdir)s/artifact_cache
 
@@ -63,10 +52,6 @@ bootstrap_buildfiles: [
     # This will pick up the whole top level BUILD file family, including BUILD.commons
     '%(buildroot)s/BUILD',
   ]
-
-
-[tasks]
-build_invalidator: %(pants_workdir)s/build_invalidator
 
 
 [ivy]
@@ -103,6 +88,7 @@ verbose: True
 
 
 [gen.thrift]
+version: 0.5.0-finagle
 java: {
     'gen': 'java:hashcode',
     'deps': {
@@ -117,12 +103,9 @@ python: {
       'structs': ['3rdparty/python:thrift']
     }
   }
-supportdir: bin/thrift
-version: 0.5.0-finagle
 
 
 [gen.protoc]
-supportdir: bin/protobuf
 version: 2.4.1
 javadeps: ['3rdparty/jvm/com/google/protobuf:protobuf-%(version)s']
 
@@ -145,43 +128,12 @@ excludes: %(buildroot)s/build-support/scalastyle/excludes.txt
 [compile.java]
 partition_size_hint: 1000000000
 jvm_options: ['-Xmx2G']
-warning_args: [
-    '-C-Xlint:all', '-C-Xlint:-serial', '-C-Xlint:-path',
-    '-C-deprecation',
-  ]
-no_warning_args: [
-    '-C-Xlint:none',
-    '-C-nowarn',
-  ]
 source: 6
 target: 6
-args: [
-    '-C-encoding', '-CUTF-8',
-    '-C-g',
-    '-C-Tcolor',
-
-    # Suppress the warning for annotations with no processor - we know there are many of these!
-    '-C-Tnowarnregex', '-C^(warning: )?No processor claimed any of these annotations: .*'
-  ]
 
 
 [compile.scala]
 jvm_options: ['-Xmx2g', '-XX:MaxPermSize=256m', '-Dzinc.analysis.cache.limit=0']
-warning_args: [
-    '-S-deprecation',
-    '-S-unchecked',
-  ]
-no_warning_args: [
-    '-S-nowarn',
-  ]
-args: [
-    '-S-encoding', '-SUTF-8',
-    '-S-g:vars',
-  ]
-
-
-[jvm]
-debug_args: ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%(debug_port)s']
 
 
 [repl.scala]
@@ -208,9 +160,8 @@ interpreter_requirement: CPython>=2.7,<3
 
 
 [python-repos]
-repos: [
-  'https://raw.github.com/twitter/commons/binaries/pants/third_party/python/dist/index.html',
-  'https://raw.github.com/twitter/commons/binaries/pants/third_party/python/index.html']
+# The custom repo is only needed for antlr-python-runtime.
+repos: ['https://raw.github.com/twitter/commons/binaries/pants/third_party/python/index.html']
 
+# Since we specify a custom repos list, we need to re-enable pypi as our source for all the rest.
 indexes: ['https://pypi.python.org/simple/']
-

--- a/src/java/com/twitter/common/application/BUILD
+++ b/src/java/com/twitter/common/application/BUILD
@@ -14,13 +14,13 @@
 # limitations under the License.
 # ==================================================================================================
 
-ACTION_SOURCES = set([
-    'Lifecycle.java',
-    'ShutdownRegistry.java',
-    'ShutdownStage.java',
-    'StartupRegistry.java',
-    'StartupStage.java',
-])
+ACTION_SOURCES = [
+  'Lifecycle.java',
+  'ShutdownRegistry.java',
+  'ShutdownStage.java',
+  'StartupRegistry.java',
+  'StartupStage.java',
+]
 
 java_library(name = 'action',
   provides = artifact(
@@ -52,5 +52,5 @@ java_library(name = 'application',
     'src/java/com/twitter/common/base',
     'src/java/com/twitter/common/net/http/handlers',
   ],
-  sources = globs('*.java') - ACTION_SOURCES
+  sources = globs('*.java', exclude = [ACTION_SOURCES])
 )

--- a/src/java/com/twitter/common/args/BUILD
+++ b/src/java/com/twitter/common/args/BUILD
@@ -89,7 +89,7 @@ java_library(name = 'args',
     ':apt',
     ':core',
   ],
-  sources = rglobs('*.java', exclude = [APT_SOURCES + CORE_SOURCES + DURATION_PARSER])
+  sources = rglobs('*.java', exclude = [APT_SOURCES, CORE_SOURCES, DURATION_PARSER])
 )
 
 java_library(name = 'duration_parser',

--- a/src/java/com/twitter/common/args/BUILD
+++ b/src/java/com/twitter/common/args/BUILD
@@ -29,17 +29,20 @@ jvm_app(
   bundles=[]
 )
 
-APT_SOURCES = globs('apt/*.java')
+APT_SOURCES = [
+  'apt/CmdLineProcessor.java',
+  'apt/Configuration.java',
+]
 CORE_SOURCES = [
- 'Arg.java',
- 'ArgParser.java',
- 'CmdLine.java',
- 'NoParser.java',
- 'Parser.java',
- 'ParserOracle.java',
- 'Positional.java',
- 'Verifier.java',
- 'VerifierFor.java',
+  'Arg.java',
+  'ArgParser.java',
+  'CmdLine.java',
+  'NoParser.java',
+  'Parser.java',
+  'ParserOracle.java',
+  'Positional.java',
+  'Verifier.java',
+  'VerifierFor.java',
 ]
 DURATION_PARSER = ['parsers/TimeDurationParser.java']
 
@@ -86,7 +89,7 @@ java_library(name = 'args',
     ':apt',
     ':core',
   ],
-  sources = rglobs('*.java') - APT_SOURCES - CORE_SOURCES - DURATION_PARSER
+  sources = rglobs('*.java', exclude = [APT_SOURCES + CORE_SOURCES + DURATION_PARSER])
 )
 
 java_library(name = 'duration_parser',

--- a/src/java/com/twitter/common/inject/BUILD
+++ b/src/java/com/twitter/common/inject/BUILD
@@ -14,9 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-
-
-TIMED_SOURCES = set([ 'TimedInterceptor.java' ])
+TIMED_SOURCES = ['TimedInterceptor.java']
 
 java_library(name = 'inject',
   provides = artifact(
@@ -30,7 +28,7 @@ java_library(name = 'inject',
     '3rdparty/jvm/com/google/inject:guice',
     '3rdparty/jvm/com/google/inject/extensions:guice-multibindings',
   ],
-  sources = globs('*.java') - TIMED_SOURCES
+  sources = globs('*.java', exclude = [TIMED_SOURCES])
 )
 
 java_library(name = 'timed',

--- a/src/java/com/twitter/common/net/BUILD
+++ b/src/java/com/twitter/common/net/BUILD
@@ -14,12 +14,12 @@
 # limitations under the License.
 # ==================================================================================================
 
-DYNAMIC_HOST_SET_SOURCES = set([ 'pool/DynamicHostSet.java' ])
+DYNAMIC_HOST_SET_SOURCES = ['pool/DynamicHostSet.java']
 
-URL_RESOLVER_SOURCES = set([
+URL_RESOLVER_SOURCES = [
   'UrlResolver.java',
   'UrlResolverUtil.java'
-])
+]
 
 java_library(name = 'dynamic-host-set',
   provides = artifact(
@@ -47,7 +47,7 @@ java_library(name = 'util',
     'src/java/com/twitter/common/base',
     'src/java/com/twitter/common/collections',
   ],
-  sources = globs('*.java') - URL_RESOLVER_SOURCES
+  sources = globs('*.java', exclude = [URL_RESOLVER_SOURCES])
 )
 
 java_library(name = 'url-resolver',
@@ -82,6 +82,6 @@ java_library(name = 'pool',
     'src/java/com/twitter/common/util',
     'src/java/com/twitter/common/util:system-mocks',
   ],
-  sources = globs('pool/*.java', 'monitoring/*.java', 'loadbalancing/*.java')
-    - DYNAMIC_HOST_SET_SOURCES
+  sources = globs('pool/*.java', 'monitoring/*.java', 'loadbalancing/*.java',
+                  exclude = [DYNAMIC_HOST_SET_SOURCES])
 )

--- a/src/java/com/twitter/common/net/http/handlers/BUILD
+++ b/src/java/com/twitter/common/net/http/handlers/BUILD
@@ -77,10 +77,10 @@ java_library(
     'src/java/com/twitter/common/stats',
   ],
   sources=globs('*.java',
-                exclude=[TEXT_SOURCES +
-                         STRING_TEMPLATE_SOURCES +
-                         THRIFT_SOURCES +
-                         TIME_SERIES_SOURCES +
+                exclude=[TEXT_SOURCES,
+                         STRING_TEMPLATE_SOURCES,
+                         THRIFT_SOURCES,
+                         TIME_SERIES_SOURCES,
                          PARAMS_SOURCES]),
   resources=[
     'src/resources/com/twitter/common/net/http/handlers:log'

--- a/src/java/com/twitter/common/net/http/handlers/BUILD
+++ b/src/java/com/twitter/common/net/http/handlers/BUILD
@@ -76,12 +76,12 @@ java_library(
     'src/java/com/twitter/common/quantity',
     'src/java/com/twitter/common/stats',
   ],
-  sources=globs('*.java')
-      - TEXT_SOURCES
-      - STRING_TEMPLATE_SOURCES
-      - THRIFT_SOURCES
-      - TIME_SERIES_SOURCES
-      - PARAMS_SOURCES,
+  sources=globs('*.java',
+                exclude=[TEXT_SOURCES +
+                         STRING_TEMPLATE_SOURCES +
+                         THRIFT_SOURCES +
+                         TIME_SERIES_SOURCES +
+                         PARAMS_SOURCES]),
   resources=[
     'src/resources/com/twitter/common/net/http/handlers:log'
   ]

--- a/src/java/com/twitter/common/util/BUILD
+++ b/src/java/com/twitter/common/util/BUILD
@@ -72,8 +72,10 @@ java_library(name = 'util',
     'src/java/com/twitter/common/quantity',
     'src/java/com/twitter/common/stats',
   ],
-  sources = globs('*.java', 'concurrent/*.java')
-    - EXECUTOR_SERVICE_SHUTDOWN_SOURCES - SYSTEM_MOCKS_SOURCES - SAMPLER_SOURCES,
+  sources = globs('*.java', 'concurrent/*.java',
+                  exclude = [EXECUTOR_SERVICE_SHUTDOWN_SOURCES +
+                             SYSTEM_MOCKS_SOURCES +
+                             SAMPLER_SOURCES]),
 )
 
 java_library(name = 'system-mocks',

--- a/src/java/com/twitter/common/util/BUILD
+++ b/src/java/com/twitter/common/util/BUILD
@@ -73,8 +73,8 @@ java_library(name = 'util',
     'src/java/com/twitter/common/stats',
   ],
   sources = globs('*.java', 'concurrent/*.java',
-                  exclude = [EXECUTOR_SERVICE_SHUTDOWN_SOURCES +
-                             SYSTEM_MOCKS_SOURCES +
+                  exclude = [EXECUTOR_SERVICE_SHUTDOWN_SOURCES,
+                             SYSTEM_MOCKS_SOURCES,
                              SAMPLER_SOURCES]),
 )
 

--- a/src/python/twitter/checkstyle/plugins/BUILD
+++ b/src/python/twitter/checkstyle/plugins/BUILD
@@ -68,7 +68,7 @@ python_library(
 
 python_library(
   name = 'twitter',
-  sources = globs('*.py') - ['pep8.py', 'pyflakes.py'],
+  sources = globs('*.py', exclude=['pep8.py', 'pyflakes.py']),
   dependencies = [
     ':plugin',
     'src/python/twitter/checkstyle:common',

--- a/src/python/twitter/common/java/perfdata/BUILD
+++ b/src/python/twitter/common/java/perfdata/BUILD
@@ -16,7 +16,7 @@
 
 python_library(
   name = 'perfdata',
-  sources = globs('*.py') + globs('builders/*.py'),
+  sources = globs('*.py', 'builders/*.py'),
   dependencies = [
     'src/python/twitter/common/lang',
   ]

--- a/src/python/twitter/common/python/BUILD
+++ b/src/python/twitter/common/python/BUILD
@@ -28,7 +28,7 @@ python_requirement_library(
 
 python_library(
   name = 'python-source',
-  sources = globs('*.py') + globs('http/*.py'),
+  sources = globs('*.py', 'http/*.py'),
 )
 
 

--- a/src/python/twitter/common/recordio/BUILD
+++ b/src/python/twitter/common/recordio/BUILD
@@ -16,7 +16,7 @@
 
 python_library(
   name = "recordio",
-  sources = rglobs('*.py') - ['thrift_recordio.py'],
+  sources = rglobs('*.py', exclude = ['thrift_recordio.py']),
   dependencies = [
     'src/python/twitter/common/log',
     'src/python/twitter/common/lang'

--- a/src/python/twitter/common/zookeeper/group/BUILD
+++ b/src/python/twitter/common/zookeeper/group/BUILD
@@ -9,7 +9,7 @@ python_library(
 
 python_library(
   name = 'group',
-  sources = globs('*.py') - ['kazoo_group.py'],
+  sources = globs('*.py', exclude = ['kazoo_group.py']),
   dependencies = [
     ':group_base',
     'src/python/twitter/common/concurrent',

--- a/src/python/twitter/common/zookeeper/serverset/BUILD
+++ b/src/python/twitter/common/zookeeper/serverset/BUILD
@@ -1,6 +1,6 @@
 python_library(
   name = 'serverset_base',
-  sources = globs('*.py') - ['cli.py'],
+  sources = globs('*.py', exclude = ['cli.py']),
   dependencies = [
     'src/python/twitter/common/lang',
     'src/python/twitter/common/zookeeper/group:group_base',

--- a/src/resources/com/twitter/common/webassets/bootstrap/BUILD
+++ b/src/resources/com/twitter/common/webassets/bootstrap/BUILD
@@ -14,17 +14,14 @@
 # limitations under the License.
 # ==================================================================================================
 
-
-def version_sources(*versions):
-  def specs():
-    for version in versions:
-      for pattern in ('css/*.css', 'js/*.js', 'img/*.png'):
-        yield '%s/%s' % (version, pattern)
-
-  return globs(*specs())
-
-
 resources(
   name='bootstrap',
-  sources=version_sources('2.1.1', '2.3.2')
+  sources=globs(
+    '2.1.1/css/*.css',
+    '2.1.1/img/*.png',
+    '2.1.1/js/*.js',
+    '2.3.2/css/*.css',
+    '2.3.2/img/*.png',
+    '2.3.2/js/*.js',
+  )
 )

--- a/src/resources/com/twitter/common/webassets/bootstrap/BUILD
+++ b/src/resources/com/twitter/common/webassets/bootstrap/BUILD
@@ -15,12 +15,16 @@
 # ==================================================================================================
 
 
-def version_sources(version):
-  specs = ['%s/%s' % (version, pattern) for pattern in ('css/*.css', 'js/*.js', 'img/*.png')]
-  return globs(*specs)
+def version_sources(*versions):
+  def specs():
+    for version in versions:
+      for pattern in ('css/*.css', 'js/*.js', 'img/*.png'):
+        yield '%s/%s' % (version, pattern)
+
+  return globs(*specs())
 
 
 resources(
   name='bootstrap',
-  sources=version_sources('2.1.1') + version_sources('2.3.2')
+  sources=version_sources('2.1.1', '2.3.2')
 )

--- a/tests/java/com/twitter/common/application/BUILD
+++ b/tests/java/com/twitter/common/application/BUILD
@@ -28,5 +28,5 @@ java_tests(name = 'application',
     'src/java/com/twitter/common/net:util',
     'src/java/com/twitter/common/testing/easymock',
   ],
-  sources = rglobs('*.java') - ['modules/LifecycleModuleTest.java']
+  sources = rglobs('*.java', exclude = ['modules/LifecycleModuleTest.java'])
 )

--- a/tests/java/com/twitter/common/args/BUILD
+++ b/tests/java/com/twitter/common/args/BUILD
@@ -27,7 +27,14 @@ java_tests(name='small',
     'src/java/com/twitter/common/args:apt',
     'src/java/com/twitter/common/args:duration_parser',
   ],
-  sources=rglobs('argfilterstest/*.java') + globs('*.java', 'parsers/*.java') - MEDIUM_TESTS
+  sources=globs('*.java',
+                'parsers/*.java',
+                'argfilterstest/*.java',
+                'argfilterstest/subpackageA/*.java',
+                'argfilterstest/subpackageA/subsubpackage1/*.java',
+                'argfilterstest/subpackageB/*.java',
+                'argfilterstest/subpackageBwithSuffix/*.java',
+                exclude=[MEDIUM_TESTS])
 )
 
 java_tests(name='medium',

--- a/tests/java/com/twitter/common/util/BUILD
+++ b/tests/java/com/twitter/common/util/BUILD
@@ -26,5 +26,5 @@ java_tests(name = 'util',
     'src/java/com/twitter/common/util',
     'src/java/com/twitter/common/util:testing',
   ],
-  sources = globs('*.java') + globs('testing/*.java')
+  sources = globs('*.java', 'testing/*.java')
 )

--- a/tests/java/com/twitter/common/zookeeper/BUILD
+++ b/tests/java/com/twitter/common/zookeeper/BUILD
@@ -45,7 +45,7 @@ java_tests(name = 'small',
     'src/java/com/twitter/common/zookeeper:server-set',
     'src/thrift/com/twitter/thrift',
   ],
-  sources = globs('*.java') - MEDIUM - LARGE
+  sources = globs('*.java', exclude=[MEDIUM + LARGE])
 )
 
 java_tests(name = 'medium-main',

--- a/tests/java/com/twitter/common/zookeeper/BUILD
+++ b/tests/java/com/twitter/common/zookeeper/BUILD
@@ -45,7 +45,7 @@ java_tests(name = 'small',
     'src/java/com/twitter/common/zookeeper:server-set',
     'src/thrift/com/twitter/thrift',
   ],
-  sources = globs('*.java', exclude=[MEDIUM + LARGE])
+  sources = globs('*.java', exclude=[MEDIUM, LARGE])
 )
 
 java_tests(name = 'medium-main',

--- a/tests/python/twitter/common/dirutil/BUILD
+++ b/tests/python/twitter/common/dirutil/BUILD
@@ -22,7 +22,7 @@ python_test_suite(name = 'all',
 )
 
 python_tests(name = 'dirutil',
-  sources = globs('*.py') - ['fileset_test.py'],
+  sources = globs('*.py', exclude = ['fileset_test.py']),
   dependencies = [
     'src/python/twitter/common/contextutil',
     'src/python/twitter/common/dirutil',


### PR DESCRIPTION
This change gets rid of twitter/commons dependence on the
pantsbuild/maven bintray repo and switches over to the new
org.pantsbuild artifacts published to maven central.

Also, deprecated glob arithmetic is replaced with use of the new glob
`exclude` parameter.