### PR TITLE
fix python twitter.common.string.basic_scanf

### DIFF
--- a/src/python/twitter/common/string/__init__.py
+++ b/src/python/twitter/common/string/__init__.py
@@ -10,7 +10,7 @@ def basic_scanf(fmt_string, value_string):
     See ScanfParser class for variable description.
   """
   so = ScanfParser(fmt_string).parse(value_string)
-  if len(so.grouped()) > 0:
+  if len(so.groups()) > 0:
     raise ScanfParser.ParseError("basic_scanf does not support named arguments!")
   return so.ungrouped()
 


### PR DESCRIPTION
`ScanfResult` has `groups()`, but not `grouped()`.

https://github.com/twitter/commons/blob/caece3a053df29ac489d6bfc938f7f9f23b27e25/src/python/twitter/common/string/scanf.py#L23