### PR TITLE
fix _make_proxy_function() in twitter/common/app/__init__.py

### DIFF
--- a/src/python/twitter/common/app/__init__.py
+++ b/src/python/twitter/common/app/__init__.py
@@ -59,8 +59,8 @@ def _make_proxy_function(method_name):
       bound_method = types.MethodType(unbound_method,
                                       Application.active())
     return bound_method(*args, **kwargs)
-  proxy_function.__doc__ = getattr(Application, attribute).__doc__
-  proxy_function.__name__ = attribute
+  proxy_function.__doc__ = getattr(Application, method_name).__doc__
+  proxy_function.__name__ = method_name
   return proxy_function
 
 


### PR DESCRIPTION
`method_name` should be used instead of `attribute`.

`attribute` is actually a global variable introduced later. Current code happen to work because calling `_make_proxy_function(attribute)` makes `method_name` equal to `attribute`.
