### PR TITLE
Make args-apt resource mapping paths more robust.

### DIFF
--- a/src/java/com/twitter/common/args/apt/CmdLineProcessor.java
+++ b/src/java/com/twitter/common/args/apt/CmdLineProcessor.java
@@ -267,7 +267,7 @@ public class CmdLineProcessor extends AbstractProcessor {
       writer.printf("%d items\n", contributingClassNames.size());
       try {
         for (String className : contributingClassNames) {
-          writer.printf("%s -> %s\n", className, cmdLinePropertiesResourcePath.getName());
+          writer.printf("%s -> %s\n", className, cmdLinePropertiesResourcePath.toUri().getPath());
         }
       } finally {
         closeQuietly(writer);


### PR DESCRIPTION
Previously the code used FileObject.getName() which has no guarantees to
be anything but a friendly name.  Switch to using the FileObject URI
which has tighter semantics.  This fixes m

Previously the code used FileObject.getName() which has no guarantees to
be anything but a friendly name.  Switch to using the FileObject URI
which has tighter semantics.  This fixes mappings under Sun JDK
1.6.0_45-b06 for example and works with all four of OpenJDK & Oracle JDK
1.7.0_79 & 1.8.0_45.

https://rbcommons.com/s/twitter/r/2468/