### PR TITLE
Upgrade to pants 0.0.39

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -58,12 +58,12 @@ jar_library(
 )
 make_lib('com.typesafe.sbt', 'sbt-interface', '0.13.8', intransitive=True)
 
-jar_library(name='scala-compiler',
+target(name='scala-compiler',
   dependencies=[
     '3rdparty/jvm/org/scala-lang:scala-compiler'
   ]
 )
-jar_library(name='scala-library',
+target(name='scala-library',
   dependencies=[
     '3rdparty/jvm/org/scala-lang:scala-library'
   ]

--- a/build-support/commons/scripts/build_py_commons.sh
+++ b/build-support/commons/scripts/build_py_commons.sh
@@ -1,37 +1,20 @@
-PROJECTS=(
-  app
-  collections
-  concurrent
-  config
-  confluence
-  contextutil
-  decorators
-  dirutil
-  exceptions
-  fs
-  git
-  http
-  java
-  jira
-  lang
-  log
-  metrics
-  net
-  options
-  process
-  quantity
-  recordio:recordio-packaged
-  resourcepool
-  reviewboard
-  rpc:rpc-packaged
-  rwbuf
-  string
-  testing
-  threading
-  util
-  zookeeper
+#!/usr/bin/env bash
+
+# This script publishes all of the python commons locally with the exception of a few
+# blacklisted legacy targets.
+
+PUBLISH_BLACKLIST=(
+  # This is the old monolithic commons target - we no longer wish to publish this since
+  # it would contain code duplicate to the individual package slices it contains.
+  src/python/twitter/common
+
+  # This is the old pex package, now moved out to the pantsbuild/pex github repo and
+  # published from there.
+  src/python/twitter/common/python
 )
 
-for project in ${PROJECTS[@]}; do
-  ./pants setup-py src/python/twitter/common/$project
-done
+spec_excludes="'[$(echo ${PUBLISH_BLACKLIST[@]} | sed "s| |','|g")']"
+
+./pants \
+  --spec-excludes=\"${spec_excludes}\" \
+  setup-py --recursive src/python/twitter/common::

--- a/pants
+++ b/pants
@@ -17,7 +17,7 @@
 
 source build-support/python/libvirtualenv.sh
 
-PANTS_VERSION=0.0.38
+PANTS_VERSION=0.0.39
 
 PANTS_PACKAGES=(
   pantsbuild.pants==${PANTS_VERSION}

--- a/pants.ini
+++ b/pants.ini
@@ -87,8 +87,11 @@ strict: False
 verbose: True
 
 
-[gen.thrift]
+[thrift-binary]
 version: 0.5.0-finagle
+
+
+[gen.thrift]
 java: {
     'gen': 'java:hashcode',
     'deps': {

--- a/src/thrift/com/twitter/service/BUILD
+++ b/src/thrift/com/twitter/service/BUILD
@@ -21,5 +21,19 @@ python_thrift_library(
     sources=[
       ('tracing.thrift', 'gen.twitter.finagle.thrift')
     ]
+  ),
+  provides = setup_py(
+    name = 'twitter.common.finagle-thrift',
+    version = commons_version(),
+    description = "twitter.common thrift stubs for zipkin rpc tracing support in finagle",
+    url = 'https://github.com/twitter/commons',
+    license = 'Apache License, Version 2.0',
+    zip_safe = True,
+    classifiers = [
+      'Intended Audience :: Developers',
+      'License :: OSI Approved :: Apache Software License',
+      'Operating System :: OS Independent',
+      'Programming Language :: Python',
+    ]
   )
 )

--- a/src/thrift/com/twitter/thrift/BUILD
+++ b/src/thrift/com/twitter/thrift/BUILD
@@ -14,16 +14,32 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_thrift_library(name = 'thrift',
-  provides = artifact(
-    org = 'com.twitter.common',
-    name = 'service-thrift',
-    repo = public,
-  ),
-  sources = globs('*.thrift')
+java_thrift_library(
+  name='thrift',
+  sources=globs('*.thrift'),
+  provides=artifact(
+    org='com.twitter.common',
+    name='service-thrift',
+    repo=public,
+  )
 )
 
 python_thrift_library(
-  name = 'py-thrift',
-  sources = globs('*.thrift')
+  name='py-thrift',
+  sources=globs('*.thrift'),
+  provides = setup_py(
+    name = 'twitter.common.service-thrift',
+    version = commons_version(),
+    description = "twitter.common thrift stubs for metadata used with Twitter's service discovery "
+                  "libraries.",
+    url = 'https://github.com/twitter/commons',
+    license = 'Apache License, Version 2.0',
+    zip_safe = True,
+    classifiers = [
+      'Intended Audience :: Developers',
+      'License :: OSI Approved :: Apache Software License',
+      'Operating System :: OS Independent',
+      'Programming Language :: Python',
+    ]
+  )
 )


### PR DESCRIPTION
See the pants changelog here:
  https://pypi.python.org/pypi/pantsbuild.pants/0.0.39

This pulls in 2 important fixes for commons python:
1. Fixes broken thrift handling in the run, repl, compile, test and
   binary goals.
2. Fixes python thrift stub publishing to work in the setup-py goal.

The python thrift stub publishing fix does require a change to the old
publishing scheme where the plain python_library target depending on the
python thrift stub code would include that code in its sdist.  That
arrangment was not generally provably sound (more than one
python_library might depend on the thrift stubs in which case both woul
publish with the embedded thrift stub code).  The new arrangement just
requires published python_thrift_libraries have their own setup_py and
this change adds those for the 2 python_thrift_libraries that were
implicitly published previously.

Some additional BUILD and pants.ini config cleanups are also included.

https://rbcommons.com/s/twitter/r/2530/