### PR TITLE
Automate the release process a bit more.

### DIFF
--- a/build-support/commons/scripts/build_py_commons.sh
+++ b/build-support/commons/scripts/build_py_commons.sh
@@ -2,6 +2,8 @@
 
 # This script publishes all of the python commons locally with the exception of a few
 # blacklisted legacy targets.
+# NB: To run you'll need a `~/.pypirc` properly configured with credentials for the
+# 'twitter' user.
 
 PUBLISH_BLACKLIST=(
   # This is the old monolithic commons target - we no longer wish to publish this since
@@ -17,4 +19,7 @@ spec_excludes="'[$(echo ${PUBLISH_BLACKLIST[@]} | sed "s| |','|g")']"
 
 ./pants \
   --spec-excludes=\"${spec_excludes}\" \
-  setup-py --recursive src/python/twitter/common::
+  setup-py \
+    --recursive \
+    --run="register sdist upload" \
+    src/python/twitter/common::


### PR DESCRIPTION
Previously, registering new packages and then uploading new packages and
updated ones was a manual out of band process.  The script now does
these things with the caveat that the proper ~/.pypirc is setup for the
'twitter' user.