### PR TITLE
Upgrade to pants 0.0.40.

### DIFF
--- a/build-support/checkstyle/coding_style.xml
+++ b/build-support/checkstyle/coding_style.xml
@@ -55,9 +55,14 @@ limitations under the License.
         <property name="basedir" value="${basedir}"/>
           -->
 
+    <!-- TODO(John Sirois): Eliminate the strange `__shaded_by_pants__` package prefixes for
+         twitter custom checks from this configuration when this issue is fixed:
+           https://github.com/pantsbuild/pants/issues/1906
+    -->
+
     <!-- We use this to turn off specific checks for specific file types.
     -->
-    <module name="com.twitter.common.checkstyle.SplitSuppressionFilter">
+    <module name="__shaded_by_pants__.com.twitter.common.checkstyle.SplitSuppressionFilter">
       <property name="files" value="${checkstyle.suppression.files}"/>
     </module>
 
@@ -114,7 +119,7 @@ limitations under the License.
 
       <!-- Checks for Javadoc comments.                     -->
       <!-- See http://checkstyle.sf.net/config_javadoc.html -->
-      <module name="com.twitter.common.checkstyle.JavadocMethodRegexCheck">
+      <module name="__shaded_by_pants__.com.twitter.common.checkstyle.JavadocMethodRegexCheck">
         <!-- don't require javadoc for methods shorter than or equal to
         this many lines (including opening & closing brace lines)
         -->
@@ -155,7 +160,7 @@ limitations under the License.
       </module>
       <module name="LocalVariableName"/>
       <module name="MemberName"/>
-      <module name="com.twitter.common.checkstyle.NonOverriddenMethodName">
+      <module name="__shaded_by_pants__.com.twitter.common.checkstyle.NonOverriddenMethodName">
         <property name="format" value="^(([a-z][a-zA-Z0-9]*)|(\$tag))$" />
       </module>
       <module name="PackageName"/>
@@ -292,7 +297,7 @@ classpath." />
       <module name="SuperClone"/>
       <module name="SuperFinalize"/>
       <!-- disallow throws Throwable unless a superclass or interface requires this -->
-      <module name="com.twitter.common.checkstyle.IllegalThrowsCheck"/>
+      <module name="__shaded_by_pants__.com.twitter.common.checkstyle.IllegalThrowsCheck"/>
       <module name="PackageDeclaration">
         <property name="ignoreDirectoryName" value="true"/>
       </module>

--- a/pants
+++ b/pants
@@ -17,7 +17,7 @@
 
 source build-support/python/libvirtualenv.sh
 
-PANTS_VERSION=0.0.39
+PANTS_VERSION=0.0.40
 
 PANTS_PACKAGES=(
   pantsbuild.pants==${PANTS_VERSION}

--- a/pants.ini
+++ b/pants.ini
@@ -92,20 +92,9 @@ version: 0.5.0-finagle
 
 
 [gen.thrift]
-java: {
-    'gen': 'java:hashcode',
-    'deps': {
-      'service': ['3rdparty/jvm/org/apache/thrift:thrift-0.5.0-finagle'],
-      'structs': ['3rdparty/jvm/org/apache/thrift:thrift-0.5.0']
-    }
-  }
-python: {
-    'gen': 'py:new_style',
-    'deps': {
-      'service': ['3rdparty/python:thrift'],
-      'structs': ['3rdparty/python:thrift']
-    }
-  }
+gen_options: hashcode
+deps: ['3rdparty/jvm/org/apache/thrift:thrift-0.5.0']
+service_deps: ['3rdparty/jvm/org/apache/thrift:thrift-0.5.0-finagle']
 
 
 [gen.protoc]


### PR DESCRIPTION
Release notes are here:
  https://pypi.python.org/pypi/pantsbuild.pants/0.0.40

The upgrade necessitates a work around in our coding_style.xml for
custom Twitter Checkstyle checks that are shaded by the pants
auto-tool-shading feature.

https://rbcommons.com/s/twitter/r/2559/