### PR TITLE
Upgrade to pants 0.0.41

### DIFF
--- a/pants
+++ b/pants
@@ -17,7 +17,7 @@
 
 source build-support/python/libvirtualenv.sh
 
-PANTS_VERSION=0.0.40
+PANTS_VERSION=0.0.41
 
 PANTS_PACKAGES=(
   pantsbuild.pants==${PANTS_VERSION}

--- a/pants.ini
+++ b/pants.ini
@@ -117,15 +117,13 @@ config: %(buildroot)s/build-support/scalastyle/scalastyle_config.xml
 excludes: %(buildroot)s/build-support/scalastyle/excludes.txt
 
 
-[compile.java]
-partition_size_hint: 1000000000
-jvm_options: ['-Xmx2G']
-source: 6
-target: 6
-
-
-[compile.scala]
-jvm_options: ['-Xmx2g', '-XX:MaxPermSize=256m', '-Dzinc.analysis.cache.limit=0']
+[jvm-platform]
+platforms: {
+    'java7': {
+      'target': 7
+    },
+  }
+default_platform: java7
 
 
 [jvm.repl.scala]


### PR DESCRIPTION
The release notes are here:
  https://pypi.python.org/pypi/pantsbuild.pants/0.0.41

Of note are fixes to python chroot caching which fixes behavior of
python tasks when edits are made to a python_binary's python_library
dependencies.

https://rbcommons.com/s/twitter/r/2585/