### PR TITLE
Upgrade to pants 0.0.42.

### DIFF
--- a/pants
+++ b/pants
@@ -1,29 +1,84 @@
 #!/usr/bin/env bash
-# ==================================================================================================
-# Copyright 2011 Twitter, Inc.
-# --------------------------------------------------------------------------------------------------
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this work except in compliance with the License.
-# You may obtain a copy of the License in the LICENSE file, or at:
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# =============================== NOTE ===============================
+# This pants bootstrap script comes from the pantsbuild/setup
+# project and is intended to be checked into your code repository so
+# that any developer can check out your code and be building it with
+# pants with no prior setup needed.
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# You can learn more here: https://pantsbuild.github.io/setup
+# ====================================================================
+
+PYTHON=${PYTHON:-$(which python2.7)}
+
+PANTS_HOME="${PANTS_HOME:-${HOME}/.cache/pants/setup}"
+PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap"
+
+VENV_VERSION=13.1.0
+
+VENV_PACKAGE=virtualenv-${VENV_VERSION}
+VENV_TARBALL=${VENV_PACKAGE}.tar.gz
+
+# The high-level flow:
+# 1.) Grab pants version from pants.ini or default to latest.
+# 2.) Check for a venv via a naming/path convention and execute if found.
+# 3.) Otherwise create venv and re-exec self.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==================================================================================================
+# After that pants itself will handle making sure any requested plugins
+# are installed and up to date.
 
-source build-support/python/libvirtualenv.sh
+function tempdir {
+  mktemp -d "$1"/pants.XXXXXX
+}
 
-PANTS_VERSION=0.0.41
+# TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
+# functions.  Any tmp dir w/o a symlink pointing to it can go.
 
-PANTS_PACKAGES=(
-  pantsbuild.pants==${PANTS_VERSION}
-  pantsbuild.pants.contrib.scrooge==${PANTS_VERSION}
-)
+function bootstrap_venv {
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]
+  then
+    (
+      mkdir -p "${PANTS_BOOTSTRAP}" && \
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}") && \
+      cd ${staging_dir} && \
+      curl -O https://pypi.python.org/packages/source/v/virtualenv/${VENV_TARBALL} && \
+      tar -xzf ${VENV_TARBALL} && \
+      ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest" && \
+      mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
+    ) 1>&2
+  fi
+  echo "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
+}
 
-setup_virtualenv pants ${PANTS_PACKAGES[@]} ${PIP_OPTIONS}
+function bootstrap_pants {
+  pants_requirement="pantsbuild.pants"
+  pants_version=$(
+    grep -E "^[[:space:]]*pants_version" pants.ini 2>/dev/null | \
+      sed -E 's|^[[:space:]]*pants_version[:=][[:space:]]*([^[:space:]]+)|\1|'
+  )
+  if [[ -n "${pants_version}" ]]
+  then
+    pants_requirement="${pants_requirement}==${pants_version}"
+  else
+    pants_version="unspecified"
+  fi
 
-exec pants "$@"
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${pants_version}" ]]
+  then
+    (
+      venv_path="$(bootstrap_venv)" && \
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}") && \
+      "${PYTHON}" "${venv_path}/virtualenv.py" "${staging_dir}/install" && \
+      source "${staging_dir}/install/bin/activate" && \
+      pip install "${pants_requirement}" && \
+      ln -s "${staging_dir}/install" "${staging_dir}/${pants_version}" && \
+      mv "${staging_dir}/${pants_version}" "${PANTS_BOOTSTRAP}/${pants_version}"
+    ) 1>&2
+  fi
+  echo "${PANTS_BOOTSTRAP}/${pants_version}"
+}
+
+pants_dir=$(bootstrap_pants) && \
+exec "${pants_dir}/bin/pants" "$@"

--- a/pants.ini
+++ b/pants.ini
@@ -18,9 +18,7 @@ plugins: [
 pythonpath: [
     "%(buildroot)s/pants-plugins/src/python",
   ]
-
 backend_packages: [
-    'pants.contrib.scrooge',
     'twitter.common.pants.jvm.args',
     'twitter.common.pants.jvm.extras',
     'twitter.common.pants.python.commons',

--- a/pants.ini
+++ b/pants.ini
@@ -8,6 +8,11 @@
 ;   pants_workdir: the scratch space used to for live builds in this repo
 
 [DEFAULT]
+pants_version: 0.0.42
+
+plugins: [
+    'pantsbuild.pants.contrib.scrooge==%(pants_version)s',
+  ]
 
 # Enable our own custom loose-source plugins.
 pythonpath: [
@@ -115,6 +120,15 @@ config: %(buildroot)s/build-support/scalastyle/scalastyle_config.xml
 ; they should be trimmed back or eliminated when scalastyle is restricted to
 ; non code-gen targets:  https://jira.twitter.biz/browse/AWESOME-6870
 excludes: %(buildroot)s/build-support/scalastyle/excludes.txt
+
+
+[compile.zinc]
+# We explicitly list no plugins here since the python and pants ini file handling defaults ini
+# options from the DEFAULT section.  In this case the DEFAULT ini section defines the `plugins`
+# list for _pants_ and those plugins are not scalac plugins.
+# TODO(John Sirois): eliminate this ini section once this fix ships:
+#  https://github.com/pantsbuild/pants/issues/1803
+plugins: []
 
 
 [jvm-platform]


### PR DESCRIPTION
This change also switches over to the standard pants setup script
from https://pantsbuild.github.io/setup and uses the new pants
plugins loading mechanism.  Now the pants & plugins install is
completely controlled in pants.ini.

https://rbcommons.com/s/twitter/r/2636/