### PR TITLE
[python zookeeper] Add member_id to ServiceInstance object if provided.

### DIFF
--- a/src/python/twitter/common/zookeeper/serverset/endpoint.py
+++ b/src/python/twitter/common/zookeeper/serverset/endpoint.py
@@ -101,19 +101,19 @@ class ServiceInstance(object):
   class UnknownEndpoint(Exception): pass
 
   @classmethod
-  def unpack(cls, blob):
+  def unpack(cls, blob, member_id=None):
     try:
-      return cls.unpack_json(blob)
+      return cls.unpack_json(blob, member_id)
     except Exception as e1:
       try:
-        return cls.unpack_thrift(blob)
+        return cls.unpack_thrift(blob, member_id)
       except Exception as e2:
         log.debug('Failed to deserialize JSON: %s (%s) && Thrift: %s (%s)' % (
           e1, e1.__class__.__name__, e2, e2.__class__.__name__))
         return None
 
   @classmethod
-  def unpack_json(cls, blob):
+  def unpack_json(cls, blob, member_id=None):
     blob = json.loads(blob)
     for key in ('status', 'serviceEndpoint', 'additionalEndpoints'):
       if key not in blob:
@@ -127,23 +127,37 @@ class ServiceInstance(object):
       except ValueError:
         log.warn('Failed to deserialize shard from value %r' % shard)
         shard = None
+    if member_id is not None:
+      try:
+        member_id = int(member_id)
+      except ValueError:
+        log.warn('Failed to deserialize member_id from value %r' % member_id)
+        member_id = None
     return cls(
       service_endpoint=Endpoint(blob['serviceEndpoint']['host'], blob['serviceEndpoint']['port']),
       additional_endpoints=additional_endpoints,
       status=Status.from_string(blob['status']),
-      shard=shard)
+      shard=shard,
+      member_id=member_id)
 
   @classmethod
-  def unpack_thrift(cls, blob):
+  def unpack_thrift(cls, blob, member_id=None):
     if not isinstance(blob, ThriftServiceInstance):
       blob = thrift_deserialize(ThriftServiceInstance(), blob)
     additional_endpoints = dict((name, Endpoint.unpack_thrift(value))
       for name, value in blob.additionalEndpoints.items())
+    if member_id is not None:
+      try:
+        member_id = int(member_id)
+      except ValueError:
+        log.warn('Failed to deserialize member_id from value %r' % member_id)
+        member_id = None
     return cls(
       service_endpoint=Endpoint.unpack_thrift(blob.serviceEndpoint),
       additional_endpoints=additional_endpoints,
       status=Status.from_thrift(blob.status),
-      shard=blob.shard)
+      shard=blob.shard,
+      member_id=member_id)
 
   @classmethod
   def to_dict(cls, service_instance):
@@ -155,16 +169,25 @@ class ServiceInstance(object):
     )
     if service_instance.shard is not None:
       instance.update(shard=service_instance.shard)
+    if service_instance.member_id is not None:
+      instance.update(member_id=service_instance.member_id)
     return instance
 
   @classmethod
   def pack(cls, service_instance):
     return json.dumps(cls.to_dict(service_instance))
 
-  def __init__(self, service_endpoint, additional_endpoints=None, status='ALIVE', shard=None):
+  def __init__(
+      self,
+      service_endpoint,
+      additional_endpoints=None,
+      status='ALIVE',
+      shard=None,
+      member_id=None):
     if not isinstance(service_endpoint, Endpoint):
       raise ValueError('Expected service_endpoint to be an Endpoint, got %r' % service_endpoint)
     self._shard = shard
+    self._member_id = member_id
     self._service_endpoint = service_endpoint
     self._additional_endpoints = additional_endpoints or {}
     if not isinstance(self._additional_endpoints, dict):
@@ -199,6 +222,10 @@ class ServiceInstance(object):
   def shard(self):
     return self._shard
 
+  @property
+  def member_id(self):
+    return self._member_id
+
   def __additional_endpoints_string(self):
     return ['%s=>%s' % (key, val) for key, val in self.additional_endpoints.items()]
 
@@ -207,7 +234,8 @@ class ServiceInstance(object):
         self.service_endpoint,
         frozenset(sorted(self.__additional_endpoints_string())),
         self.status,
-        self._shard)
+        self._shard,
+        self._member_id)
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__key() == other.__key()
@@ -217,8 +245,9 @@ class ServiceInstance(object):
 
 
   def __str__(self):
-    return 'ServiceInstance(%s, %saddl: %s, status: %s)' % (
+    return 'ServiceInstance(%s, %s, %saddl: %s, status: %s)' % (
       self.service_endpoint,
       ('shard: %s, ' % self._shard) if self._shard is not None else '',
+      ('member_id: %s, ' % self._member_id) if self._member_id is not None else '',
       ' : '.join(self.__additional_endpoints_string()),
       self.status)

--- a/src/python/twitter/common/zookeeper/serverset/serverset.py
+++ b/src/python/twitter/common/zookeeper/serverset/serverset.py
@@ -82,14 +82,7 @@ class ServerSet(object):
     if on_join or on_leave:
       self._internal_monitor(set(self._members))
 
-  def join(
-      self,
-      endpoint,
-      additional=None,
-      shard=None,
-      member_id=None,
-      callback=None,
-      expire_callback=None):
+  def join(self, endpoint, additional=None, shard=None, callback=None, expire_callback=None):
     """
       Given 'endpoint' (twitter.common.zookeeper.serverset.Endpoint) and an
       optional map 'additional' of string => endpoint (also Endpoint), and an
@@ -104,8 +97,7 @@ class ServerSet(object):
       If 'expire_callback' is provided, it will be called if the membership
       is severed for any reason such as session expiration or malice.
     """
-    service_instance = ServiceInstance.pack(
-        ServiceInstance(endpoint, additional, shard=shard, member_id=member_id))
+    service_instance = ServiceInstance.pack(ServiceInstance(endpoint, additional, shard=shard))
     return self._group.join(service_instance, callback=callback, expire_callback=expire_callback)
 
   def cancel(self, membership, callback=None):

--- a/src/python/twitter/common/zookeeper/serverset/serverset.py
+++ b/src/python/twitter/common/zookeeper/serverset/serverset.py
@@ -82,7 +82,14 @@ class ServerSet(object):
     if on_join or on_leave:
       self._internal_monitor(set(self._members))
 
-  def join(self, endpoint, additional=None, shard=None, callback=None, expire_callback=None):
+  def join(
+      self,
+      endpoint,
+      additional=None,
+      shard=None,
+      member_id=None,
+      callback=None,
+      expire_callback=None):
     """
       Given 'endpoint' (twitter.common.zookeeper.serverset.Endpoint) and an
       optional map 'additional' of string => endpoint (also Endpoint), and an
@@ -97,7 +104,8 @@ class ServerSet(object):
       If 'expire_callback' is provided, it will be called if the membership
       is severed for any reason such as session expiration or malice.
     """
-    service_instance = ServiceInstance.pack(ServiceInstance(endpoint, additional, shard=shard))
+    service_instance = ServiceInstance.pack(
+        ServiceInstance(endpoint, additional, shard=shard, member_id=member_id))
     return self._group.join(service_instance, callback=callback, expire_callback=expire_callback)
 
   def cancel(self, membership, callback=None):
@@ -108,7 +116,7 @@ class ServerSet(object):
     """Iterate over the services (ServiceInstance objects) in this ServerSet."""
     for member in self._group.list():
       try:
-        yield ServiceInstance.unpack(self._group.info(member))
+        yield ServiceInstance.unpack(self._group.info(member), member_id=member.id)
       except Exception as e:
         log.warning('Failed to deserialize endpoint: %s' % e)
         continue

--- a/tests/python/twitter/common/zookeeper/serverset/test_base.py
+++ b/tests/python/twitter/common/zookeeper/serverset/test_base.py
@@ -50,25 +50,32 @@ class ServerSetTestBase(object):
     ss = ServerSet(self.make_zk(self._server.ensemble), self.SERVICE_PATH)
     assert list(ss) == []
     ss.join(self.INSTANCE1)
-    assert list(ss) == [ServiceInstance(self.INSTANCE1)]
+    assert list(ss) == [ServiceInstance(self.INSTANCE1, member_id=0)]
     ss.join(self.INSTANCE2)
-    assert list(ss) == [ServiceInstance(self.INSTANCE1), ServiceInstance(self.INSTANCE2)]
+    assert list(ss) == [
+      ServiceInstance(self.INSTANCE1, member_id=0), ServiceInstance(self.INSTANCE2, member_id=1)]
 
   def test_async_client_iteration(self):
     ss1 = ServerSet(self.make_zk(self._server.ensemble), self.SERVICE_PATH)
     ss2 = ServerSet(self.make_zk(self._server.ensemble), self.SERVICE_PATH)
     ss1.join(self.INSTANCE1)
     ss2.join(self.INSTANCE2)
-    assert list(ss1) == [ServiceInstance(self.INSTANCE1), ServiceInstance(self.INSTANCE2)]
-    assert list(ss2) == [ServiceInstance(self.INSTANCE1), ServiceInstance(self.INSTANCE2)]
+    assert list(ss1) == [
+      ServiceInstance(self.INSTANCE1, member_id=0), ServiceInstance(self.INSTANCE2, member_id=1)]
+    assert list(ss2) == [
+      ServiceInstance(self.INSTANCE1, member_id=0), ServiceInstance(self.INSTANCE2, member_id=1)]
 
   def test_shard_id_registers(self):
     ss1 = ServerSet(self.make_zk(self._server.ensemble), self.SERVICE_PATH)
     ss2 = ServerSet(self.make_zk(self._server.ensemble), self.SERVICE_PATH)
     ss1.join(self.INSTANCE1, shard=0)
     ss2.join(self.INSTANCE2, shard=1)
-    assert list(ss1) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1)]
-    assert list(ss2) == [ServiceInstance(self.INSTANCE1, shard=0), ServiceInstance(self.INSTANCE2, shard=1)]
+    assert list(ss1) == [
+      ServiceInstance(self.INSTANCE1, shard=0, member_id=0),
+      ServiceInstance(self.INSTANCE2, shard=1, member_id=1)]
+    assert list(ss2) == [
+      ServiceInstance(self.INSTANCE1, shard=0, member_id=0),
+      ServiceInstance(self.INSTANCE2, shard=1, member_id=1)]
 
   def test_canceled_join_long_time(self):
     zk = self.make_zk(self._server.ensemble)

--- a/tests/python/twitter/common/zookeeper/serverset/test_endpoint.py
+++ b/tests/python/twitter/common/zookeeper/serverset/test_endpoint.py
@@ -34,6 +34,7 @@ def _service_instance(vals):
         "port": 31181
     },
     "shard": %d,
+    "member_id": %d,
     "status": "ALIVE"
 }''' % vals
 
@@ -73,22 +74,22 @@ def test_status_hash_inequality():
 
 
 def test_service_instance_equality():
-  vals = (1, 2, 3, 4)
+  vals = (1, 2, 3, 4, 5)
   assert _service_instance(vals) == _service_instance(vals)
 
 
 def test_service_instance_hash_equality():
-  vals = (1, 2, 3, 4)
+  vals = (1, 2, 3, 4, 5)
   assert _service_instance(vals).__hash__() == _service_instance(vals).__hash__()
 
 
 def test_service_instance_inequality():
-  vals = (1, 2, 3, 4)
-  vals2 = (5, 6, 7, 8)
+  vals = (1, 2, 3, 4, 5)
+  vals2 = (6, 7, 8, 9, 10)
   assert _service_instance(vals) != _service_instance(vals2)
 
 
 def test_service_instance_hash_inequality():
-  vals = (1, 2, 3, 4)
-  vals2 = (5, 6, 7, 8)
+  vals = (1, 2, 3, 4, 5)
+  vals2 = (6, 7, 8, 9, 10)
   assert _service_instance(vals).__hash__() != _service_instance(vals2).__hash__()

--- a/tests/python/twitter/common/zookeeper/serverset/test_serverset_unit.py
+++ b/tests/python/twitter/common/zookeeper/serverset/test_serverset_unit.py
@@ -41,6 +41,7 @@ SERVICE_INSTANCE_JSON = '''{
         "port": 31510
     },
     "shard": 0,
+    "member_id": 0,
     "status": "ALIVE"
 }'''
 


### PR DESCRIPTION
Add member_id to ServiceInstance object if supplied when creating it and make that the default action when creating a serverset list. This is mostly useful for reconciling issues with the serverset e.g. duplicate registration.

Tests all pass:
$ ./pants test tests/python/twitter/common/zookeeper:all
11:22:40 00:02         [chroot]============== test session starts ===============
                     platform darwin -- Python 2.7.10 -- py-1.4.31 -- pytest-2.6.4
                     plugins: cov, timeout
                     collected 85 items

```
                 tests/python/twitter/common/zookeeper/kazoo_client_test.py .
                 tests/python/twitter/common/zookeeper/group/test_active_kazoo_group.py ................................................
                 tests/python/twitter/common/zookeeper/group/test_kazoo_group.py ..................
                 tests/python/twitter/common/zookeeper/serverset/test_endpoint.py ............
                 tests/python/twitter/common/zookeeper/serverset/test_kazoo_serverset.py .....
                 tests/python/twitter/common/zookeeper/serverset/test_serverset_unit.py .

                 =========== 85 passed in 23.80 seconds ===========
```
