### PR TITLE
python: Add IP addresses to serverset entries

### DIFF
--- a/src/thrift/com/twitter/thrift/endpoint.thrift
+++ b/src/thrift/com/twitter/thrift/endpoint.thrift
@@ -76,6 +76,18 @@ struct Endpoint {
    * The TCP port the endpoint listens on.
    */
   2: i32 port
+
+  /*
+   * The human readable representation of a IPv4 address of the endpoint.  May
+   * be used instead of a DNS lookup for host.
+   */
+  3: optional string inet
+
+  /*
+   * The IPv6 address of the endpoint. May be used instead of a DNS lookup for
+   * host.
+   */
+  4: optional string inet6
 }
 
 /*

--- a/tests/python/twitter/common/zookeeper/serverset/BUILD
+++ b/tests/python/twitter/common/zookeeper/serverset/BUILD
@@ -1,7 +1,7 @@
 python_test_suite(
   name = 'all',
   dependencies = [
-    ':endpoint',
+    ':test_endpoint',
     ':test_kazoo_serverset',
     ':test_serverset_unit',
   ],
@@ -25,7 +25,7 @@ python_tests(
 )
 
 python_tests(
-  name = 'endpoint',
+  name = 'test_endpoint',
   sources = ['test_endpoint.py'],
   dependencies = [
     'src/python/twitter/common/zookeeper/serverset:serverset_base'

--- a/tests/python/twitter/common/zookeeper/serverset/test_endpoint.py
+++ b/tests/python/twitter/common/zookeeper/serverset/test_endpoint.py
@@ -14,7 +14,88 @@
 # limitations under the License.
 # ==================================================================================================
 
+import pytest
 from twitter.common.zookeeper.serverset.endpoint import Endpoint, ServiceInstance, Status
+
+
+def test_endpoint_constructor():
+  # Check that those do not throw
+  Endpoint('host', 8340)
+  Endpoint('host', 8340, '1.2.3.4')
+  Endpoint('host', 8340, None, '2001:db8:1234:ffff:ffff:ffff:ffff:ffff')
+  Endpoint('host', 8340, '1.2.3.4', '2001:db8:1234:ffff:ffff:ffff:ffff:ffff')
+
+  with pytest.raises(ValueError):
+    Endpoint('host', 8340, 'not an IP')
+  with pytest.raises(ValueError):
+    Endpoint('host', 8340, None, 'not an IPv6')
+
+
+def test_endpoint_equality():
+  assert Endpoint('host', 8340) == Endpoint('host', 8340)
+  assert Endpoint('host', 8340, '1.2.3.4') == Endpoint('host', 8340, '1.2.3.4')
+  assert (Endpoint('host', 8340, '1.2.3.4', '2001:db8:1234:ffff:ffff:ffff:ffff:ffff')
+          == Endpoint('host', 8340, '1.2.3.4', '2001:db8:1234:ffff:ffff:ffff:ffff:ffff'))
+  assert (Endpoint('host', 8340, None, '2001:db8:1234:ffff:ffff:ffff:ffff:ffff')
+          == Endpoint('host', 8340, None, '2001:db8:1234:ffff:ffff:ffff:ffff:ffff'))
+
+
+def test_endpoint_hash_equality():
+  assert Endpoint('host', 8340).__hash__() == Endpoint('host', 8340).__hash__()
+  assert Endpoint('host', 8340, '1.2.3.4').__hash__() == Endpoint('host', 8340, '1.2.3.4').__hash__()
+  assert (Endpoint('host', 8340, '1.2.3.4', '2001:db8:1234:ffff:ffff:ffff:ffff:ffff').__hash__()
+          == Endpoint('host', 8340, '1.2.3.4', '2001:db8:1234:ffff:ffff:ffff:ffff:ffff').__hash__())
+  assert (Endpoint('host', 8340, None, '2001:db8:1234:ffff:ffff:ffff:ffff:ffff').__hash__()
+          == Endpoint('host', 8340, None, '2001:db8:1234:ffff:ffff:ffff:ffff:ffff').__hash__())
+
+
+def test_endpoint_inequality():
+  assert Endpoint('host', 8340) != Endpoint('xhost', 8340)
+  assert Endpoint('host', 8340) != Endpoint('host', 8341)
+  assert (Endpoint('host', 8340, '1.2.3.4', '2001:db8:1234:ffff:ffff:ffff:ffff:ffff')
+          != Endpoint('host', 8340, '5.6.7.8', '2001:db8:5678:ffff:ffff:ffff:ffff:ffff'))
+  assert (Endpoint('host', 8340, None, '2001:db8:1234:ffff:ffff:ffff:ffff:ffff')
+          != Endpoint('host', 8340, None, '2001:db8:5678:ffff:ffff:ffff:ffff:ffff'))
+
+
+def test_endpoint_hash_inequality():
+  assert Endpoint('host', 8340).__hash__() != Endpoint('xhost', 8341).__hash__()
+  assert Endpoint('host', 8340).__hash__() != Endpoint('host', 8341).__hash__()
+  assert (Endpoint('host', 8340, '1.2.3.4', '2001:db8:1234:ffff:ffff:ffff:ffff:ffff').__hash__()
+          != Endpoint('host', 8340, '5.6.7.8', '2001:db8:5678:ffff:ffff:ffff:ffff:ffff').__hash__())
+  assert (Endpoint('host', 8340, None, '2001:db8:1234:ffff:ffff:ffff:ffff:ffff').__hash__()
+          != Endpoint('host', 8340, None, '2001:db8:5678:ffff:ffff:ffff:ffff:ffff').__hash__())
+
+
+def test_endpoint_from_dict():
+  expected = {
+    Endpoint('smfd-akb-12-sr1', 31181): {'host': 'smfd-akb-12-sr1', 'port': 31181},
+    Endpoint('smfd-akb-12-sr1', 31181, '1.2.3.4'): {'host': 'smfd-akb-12-sr1', 'port': 31181, 'inet': '1.2.3.4'},
+    Endpoint('smfd-akb-12-sr1', 31181, '1.2.3.4', '2001:db8:5678:ffff:ffff:ffff:ffff:ffff'):
+      {'host': 'smfd-akb-12-sr1', 'port': 31181, 'inet': '1.2.3.4', 'inet6':
+       '2001:db8:5678:ffff:ffff:ffff:ffff:ffff'},
+    Endpoint('smfd-akb-12-sr1', 31181, None, '2001:db8:5678:ffff:ffff:ffff:ffff:ffff'):
+      {'host': 'smfd-akb-12-sr1', 'port': 31181, 'inet6': '2001:db8:5678:ffff:ffff:ffff:ffff:ffff'}
+  }
+  for (endpoint, dic) in expected.items():
+    assert Endpoint.to_dict(endpoint) == dic
+    assert Endpoint.from_dict(dic) == endpoint
+
+
+def test_status_equality():
+  assert Status.from_string('DEAD') == Status.from_string('DEAD')
+
+
+def test_status_hash_equality():
+  assert Status.from_string('DEAD').__hash__() == Status.from_string('DEAD').__hash__()
+
+
+def test_status_inequality():
+  assert Status.from_string('DEAD') != Status.from_string('STARTING')
+
+
+def test_status_hash_inequality():
+  assert Status.from_string('DEAD').__hash__() != Status.from_string('STARTING').__hash__()
 
 
 def _service_instance(vals):
@@ -34,62 +115,70 @@ def _service_instance(vals):
         "port": 31181
     },
     "shard": %d,
-    "member_id": %d,
     "status": "ALIVE"
 }''' % vals
 
   return ServiceInstance.unpack(json)
 
 
-def test_endpoint_equality():
-  assert Endpoint('host', 8340) == Endpoint('host', 8340)
-
-
-def test_endpoint_hash_equality():
-  assert Endpoint('host', 8340).__hash__() == Endpoint('host', 8340).__hash__()
-
-
-def test_endpoint_inequality():
-  assert Endpoint('host', 8340) != Endpoint('xhost', 8341)
-
-
-def test_endpoint_hash_inequality():
-  assert Endpoint('host', 8340).__hash__() != Endpoint('xhost', 8341).__hash__()
-
-
-def test_status_equality():
-  assert Status.from_string('DEAD') == Status.from_string('DEAD')
-
-
-def test_status_hash_equality():
-  assert Status.from_string('DEAD').__hash__() == Status.from_string('DEAD').__hash__()
-
-
-def test_status_inequality():
-  assert Status.from_string('DEAD') != Status.from_string('STARTING')
-
-
-def test_status_hash_inequality():
-  assert Status.from_string('DEAD').__hash__() != Status.from_string('STARTING').__hash__()
-
-
 def test_service_instance_equality():
-  vals = (1, 2, 3, 4, 5)
+  vals = (1, 2, 3, 4)
   assert _service_instance(vals) == _service_instance(vals)
 
 
 def test_service_instance_hash_equality():
-  vals = (1, 2, 3, 4, 5)
+  vals = (1, 2, 3, 4)
   assert _service_instance(vals).__hash__() == _service_instance(vals).__hash__()
 
 
 def test_service_instance_inequality():
-  vals = (1, 2, 3, 4, 5)
-  vals2 = (6, 7, 8, 9, 10)
+  vals = (1, 2, 3, 4)
+  vals2 = (5, 6, 7, 8)
   assert _service_instance(vals) != _service_instance(vals2)
 
 
 def test_service_instance_hash_inequality():
-  vals = (1, 2, 3, 4, 5)
-  vals2 = (6, 7, 8, 9, 10)
+  vals = (1, 2, 3, 4)
+  vals2 = (5, 6, 7, 8)
   assert _service_instance(vals).__hash__() != _service_instance(vals2).__hash__()
+
+
+def test_service_instance_to_json():
+  json = """{
+    "additionalEndpoints": {
+        "aurora": {
+            "host": "hostname",
+            "inet6": "2001:db8:1234:ffff:ffff:ffff:ffff:ffff",
+            "port": 22
+        },
+        "health": {
+            "host": "hostname",
+            "inet": "1.2.3.4",
+            "port": 23
+        },
+        "http": {
+            "host": "hostname",
+            "inet": "1.2.3.4",
+            "inet6": "2001:db8:1234:ffff:ffff:ffff:ffff:ffff",
+            "port": 23
+        }
+    },
+    "serviceEndpoint": {
+        "host": "hostname",
+        "port": 24
+    },
+    "shard": 1,
+    "status": "ALIVE"
+  }"""
+  service_instance = ServiceInstance(
+    Endpoint("hostname", 24),
+    {"aurora": Endpoint("hostname", 22, "1.2.3.4"),
+     "health": Endpoint("hostname", 23, None, "2001:db8:1234:ffff:ffff:ffff:ffff:ffff"),
+     "http": Endpoint("hostname", 23, "1.2.3.4", "2001:db8:1234:ffff:ffff:ffff:ffff:ffff"),
+   },
+    'ALIVE',
+    1
+  )
+
+  assert ServiceInstance.unpack(json) == service_instance
+  assert ServiceInstance.unpack(ServiceInstance.pack(service_instance)) == service_instance

--- a/tests/python/twitter/common/zookeeper/serverset/test_serverset_unit.py
+++ b/tests/python/twitter/common/zookeeper/serverset/test_serverset_unit.py
@@ -29,16 +29,20 @@ SERVICE_INSTANCE_JSON = '''{
     "additionalEndpoints": {
         "aurora": {
             "host": "smfd-aki-15-sr1.devel.twitter.com",
-            "port": 31510
+            "port": 31510,
+            "inet": "1.2.3.4"
         },
         "health": {
             "host": "smfd-aki-15-sr1.devel.twitter.com",
-            "port": 31510
+            "port": 31511,
+            "inet6": "2001:db8:1234:ffff:ffff:ffff:ffff:ffff"
         }
     },
     "serviceEndpoint": {
         "host": "smfd-aki-15-sr1.devel.twitter.com",
-        "port": 31510
+        "port": 31512,
+        "inet": "1.2.3.4",
+        "inet6": "2001:db8:1234:ffff:ffff:ffff:ffff:ffff"
     },
     "shard": 0,
     "member_id": 0,


### PR DESCRIPTION
ServerSet entries contain hostnames that require a DNS lookup before
use. When hostnames map to a unique, fixed IP address, this additional
lookup is unnecessary and can put strain on DNS infrastructure in large
deployments.

This change add 2 optional fields to server set endpoints: `inet` and
`inet6` respectively for a human readable representation of an IPv4 and
of an IPv6 address.

Hostnames are still mandatory, for backward compatibility with clients
that expect it.