### PR TITLE
Repair ./rbt for review posting.

### DIFF
--- a/build-support/python/libvirtualenv.sh
+++ b/build-support/python/libvirtualenv.sh
@@ -1,0 +1,20 @@
+function setup_virtualenv() {
+  script="$1"; shift        # 'rbt'
+  requirements="$1"; shift  # 'RBTools==0.5.5'
+  pip_install_opts="$@"     # '--allow-external RBTools --allow-unverified RBTools'
+  fingerprint=$(echo $script $requirements | openssl md5 | cut -d' ' -f2)
+
+  HERE=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+  VENV_DIR="$HERE/../${script}.venv"
+  BOOTSTRAPPED_FILE="${VENV_DIR}/BOOTSTRAPPED.${fingerprint}"
+  if ! [ -f ${BOOTSTRAPPED_FILE} ]; then
+    echo "Bootstrapping ${script} with requirements ${requirements}"
+    rm -fr "${VENV_DIR}"
+    "$HERE/../virtualenv" "${VENV_DIR}"
+    source "${VENV_DIR}/bin/activate"
+    pip install ${pip_install_opts} "${requirements}"
+    touch "${BOOTSTRAPPED_FILE}"
+  else
+    source "${VENV_DIR}/bin/activate"
+  fi
+}

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Wrapper for self-bootstrapping virtualenv
+set -e
+
+VIRTUALENV_VERSION=15.0.1
+
+if which python2.7 >/dev/null; then
+  PY=`which python2.7`
+else
+  echo 'No python interpreter found on the path.  Python will not work!' 1>&2
+  exit 1
+fi
+
+echo "Using $PY" >&2
+
+HERE=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+if ! [ -f "$HERE/virtualenv.dist/BOOTSTRAPPED-$VIRTUALENV_VERSION" ]; then
+  pushd "$HERE"
+  curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-$VIRTUALENV_VERSION.tar.gz
+  tar zxvf virtualenv-$VIRTUALENV_VERSION.tar.gz
+  # TODO(ksweeney): Checksum
+  touch virtualenv-$VIRTUALENV_VERSION/BOOTSTRAPPED-$VIRTUALENV_VERSION  # 2PC
+  rm -rf virtualenv.dist
+  mv virtualenv-$VIRTUALENV_VERSION virtualenv.dist
+  popd
+fi
+
+exec "$PY" "$HERE/virtualenv.dist/virtualenv.py" "$@"

--- a/rbt
+++ b/rbt
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 source build-support/python/libvirtualenv.sh
-setup_virtualenv 'rbt' 'RBTools==0.7.4' \
-  '--allow-external RBTools'
+setup_virtualenv 'rbt' 'RBTools==0.7.6'
 exec rbt "$@"


### PR DESCRIPTION
This addresses breakage in the `./rbt` utility for posting reviews to RBcommons and includes version bumps for both `virtualenv` and `rbtools` to their latest pypi versions.
