### PR TITLE
Added CommandUtil.cmd_within_path() and patched twitter.common.fs.hdfs

### DIFF
--- a/src/python/twitter/common/fs/hdfs.py
+++ b/src/python/twitter/common/fs/hdfs.py
@@ -51,10 +51,8 @@ class HDFSHelper(object):
     if heap_limit is None:
       raise ValueError('The hdfs heap_limit must not be specified as "None".')
     self._heap_limit = heap_limit
-    self.cli_command = 'hdfs'
-    if use_hadoop_v1:
-      self.cli_command = 'hadoop'
-    if self._cmd_class.execute_suppress_stdout_stderr(self.cli_command) != 0:
+    self.cli_command = 'hadoop' if use_hadoop_v1 else 'hdfs'
+    if self._cmd_class.cmd_within_path(self.cli_command):
       raise OSError('The "{0}" utility is not available on the system PATH'.format(
         self.cli_command))
 

--- a/src/python/twitter/common/util/command_util.py
+++ b/src/python/twitter/common/util/command_util.py
@@ -125,3 +125,11 @@ class CommandUtil(object):
     return CommandUtil._execute_internal(cmd, True, True, log_cmd, None, True)
     """
     return CommandUtil._execute_internal(cmd, True, False, log_cmd, None, True)
+
+  @staticmethod
+  def cmd_within_path(cmd):
+    """
+    Verify command is within the environment PATH
+    return True or False
+    """
+    return any(os.access(os.path.join(path, cmd), os.X_OK) for path in os.environ["PATH"].split(os.pathsep))

--- a/tests/python/twitter/common/util/command_util_test.py
+++ b/tests/python/twitter/common/util/command_util_test.py
@@ -96,3 +96,7 @@ class CommandUtilTest(unittest.TestCase):
     (ret, output) = CommandUtil.execute_and_get_output(['echo1', 'test'])
     self.assertEqual(ret, 1)
     self.assertEqual(output, None)
+
+  def test_cmd_within_path(self):
+    self.assertEqual(CommandUtil.cmd_within_path('ls'), True)
+    self.assertEqual(CommandUtil.cmd_within_path('xxx'), False)


### PR DESCRIPTION
This will move the 'hdfs' and/or 'hadoop' executable check to PATH verification