### PR TITLE
Fix inverted existence check for hdfs/hadoop command

### DIFF
--- a/src/python/twitter/common/fs/hdfs.py
+++ b/src/python/twitter/common/fs/hdfs.py
@@ -52,7 +52,7 @@ class HDFSHelper(object):
       raise ValueError('The hdfs heap_limit must not be specified as "None".')
     self._heap_limit = heap_limit
     self.cli_command = 'hadoop' if use_hadoop_v1 else 'hdfs'
-    if self._cmd_class.cmd_within_path(self.cli_command):
+    if not self._cmd_class.cmd_within_path(self.cli_command):
       raise OSError('The "{0}" utility is not available on the system PATH'.format(
         self.cli_command))
 


### PR DESCRIPTION
twitter.commons.fs.hdfs was broken by 18d4bbc8fb1c9fc5a2bcf9c3190aefcfcf36890b - When checking for the 'hdfs' or 'hadoop' commands, if the command does exist in the path the OSError is raised. Instead, the if statement needs to be inverted 