### PR TITLE
Update styleguide.md

### DIFF
--- a/src/java/com/twitter/common/styleguide.md
+++ b/src/java/com/twitter/common/styleguide.md
@@ -272,7 +272,7 @@ if you expect a specific operation ordering, make it obvious with parenthesis.
     return a << 8 * n + 1 | 0xFF;
 
     // Good.
-    return (a << (8 * n) + 1) | 0xFF;
+    return (a << (8 * n + 1)) | 0xFF;
 
 It's even good to be *really* obvious.
 


### PR DESCRIPTION
I think that 

> `(a << (8 * n) + 1) | 0xFF`
> is a bit less obvious than:
> `(a << (8 * n + 1)) | 0xFF`
> Because it's a bit harder to guess which has a higher precedence: `+` or `>>`.
> But muck easier to guess that a `*` has a higher precedence than `+`. Except that, `*` is placed left, so even if the reader is confused about the precedence of `+` and `*`, than he may just apply those operations one by one from left to right just as they would be with the same precedence.
