### PR TITLE
Bump pants to 1.3.0.dev14 and fix deprecation warnings

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -45,7 +45,7 @@ done
 # flip-flop that settled out at 3.3.  Make sure travis-ci
 # for example does not attempt to setup a 3.2 interpreter.
 INTERPRETER_CONSTRAINTS=(
-  "CPython>=2.6,<3"
+  "CPython>=2.7,<3"
   "CPython>=3.3"
 )
 for constraint in ${INTERPRETER_CONSTRAINTS[@]}; do
@@ -101,7 +101,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     )
     ./pants \
       ${compile_exclusions[@]/#/--exclude-target-regexp=} \
-      compile.python-eval --fail-slow src/python/::
+      compile.python-eval --no-skip src/python/::
   ) || die "Python compile failure"
 
   banner "Running python tests"
@@ -109,7 +109,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     # TODO(John Sirois): We clean-all here to work-around args resource mapper issues finding leftover
     # entries from args tests in the jvm tests above, kill the clean-all once the resource mapper bug
     # is identified and fixed.
-    ./pants --timeout=5 ${INTERPRETER_ARGS[@]} clean-all test.pytest --fail-slow --no-fast \
+    ./pants --timeout=5 ${INTERPRETER_ARGS[@]} clean-all test.pytest --no-fast \
       tests/python/twitter/common:all
   ) || die "Python test failure"
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -44,7 +44,16 @@ done
 # Pants does not work with 3.0-3.2 due to the unicode
 # flip-flop that settled out at 3.3.  Make sure travis-ci
 # for example does not attempt to setup a 3.2 interpreter.
-INTERPRETER_ARGS="--python-setup-interpreter-constraints='[\"CPython>=2.7,<3\",\"CPython>=3.3\"]'"
+INTERPRETER_CONSTRAINTS=(
+  "CPython>=2.7,<3"
+  "CPython>=3.3"
+)
+for constraint in ${INTERPRETER_CONSTRAINTS[@]}; do
+  INTERPRETER_ARGS=(
+    ${INTERPRETER_ARGS[@]}
+    --python-setup-interpreter-constraints="${constraint}"
+  )
+done
 
 banner "CI BEGINS"
 
@@ -66,8 +75,8 @@ fi
 if [[ "${skip_java:-false}" == "false" ]]; then
   banner "Running jvm tests"
   (
-    ./pants -x ${INTERPRETER_ARGS} test {src,tests}/java/com/twitter/common:: && \
-    ./pants -x ${INTERPRETER_ARGS} test {src,tests}/scala/com/twitter/common::
+    ./pants -x ${INTERPRETER_ARGS[@]} test {src,tests}/java/com/twitter/common:: && \
+    ./pants -x ${INTERPRETER_ARGS[@]} test {src,tests}/scala/com/twitter/common::
   ) || die "Jvm test failure."
 fi
 
@@ -100,7 +109,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     # TODO(John Sirois): We clean-all here to work-around args resource mapper issues finding leftover
     # entries from args tests in the jvm tests above, kill the clean-all once the resource mapper bug
     # is identified and fixed.
-    ./pants --timeout=5 ${INTERPRETER_ARGS} clean-all test.pytest --no-fast \
+    ./pants --timeout=5 ${INTERPRETER_ARGS[@]} clean-all test.pytest --no-fast \
       tests/python/twitter/common:all
   ) || die "Python test failure"
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -44,16 +44,7 @@ done
 # Pants does not work with 3.0-3.2 due to the unicode
 # flip-flop that settled out at 3.3.  Make sure travis-ci
 # for example does not attempt to setup a 3.2 interpreter.
-INTERPRETER_CONSTRAINTS=(
-  "CPython>=2.7,<3"
-  "CPython>=3.3"
-)
-for constraint in ${INTERPRETER_CONSTRAINTS[@]}; do
-  INTERPRETER_ARGS=(
-    ${INTERPRETER_ARGS[@]}
-    --interpreter="${constraint}"
-  )
-done
+INTERPRETER_ARGS="--python-setup-interpreter-constraints='[\"CPython>=2.7,<3\",\"CPython>=3.3\"]'"
 
 banner "CI BEGINS"
 
@@ -75,8 +66,8 @@ fi
 if [[ "${skip_java:-false}" == "false" ]]; then
   banner "Running jvm tests"
   (
-    ./pants -x ${INTERPRETER_ARGS[@]} test {src,tests}/java/com/twitter/common:: && \
-    ./pants -x ${INTERPRETER_ARGS[@]} test {src,tests}/scala/com/twitter/common::
+    ./pants -x ${INTERPRETER_ARGS} test {src,tests}/java/com/twitter/common:: && \
+    ./pants -x ${INTERPRETER_ARGS} test {src,tests}/scala/com/twitter/common::
   ) || die "Jvm test failure."
 fi
 
@@ -109,7 +100,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     # TODO(John Sirois): We clean-all here to work-around args resource mapper issues finding leftover
     # entries from args tests in the jvm tests above, kill the clean-all once the resource mapper bug
     # is identified and fixed.
-    ./pants --timeout=5 ${INTERPRETER_ARGS[@]} clean-all test.pytest --no-fast \
+    ./pants --timeout=5 ${INTERPRETER_ARGS} clean-all test.pytest --no-fast \
       tests/python/twitter/common:all
   ) || die "Python test failure"
 fi

--- a/pants.ini
+++ b/pants.ini
@@ -8,7 +8,7 @@
 ;   pants_workdir: the scratch space used to for live builds in this repo
 
 [GLOBAL]
-pants_version: 1.2.1
+pants_version: 1.3.0.dev14
 
 plugins: [
     'pantsbuild.pants.contrib.scrooge==%(pants_version)s',
@@ -168,6 +168,7 @@ version: 2.10
 [python-setup]
 # We only support commons python code running under 2.7 for now with 3.3+ support to be added later.
 interpreter_requirement: CPython>=2.7,<3
+resolver_allow_prereleases: True
 
 
 [python-repos]

--- a/pants.ini
+++ b/pants.ini
@@ -81,8 +81,8 @@ verbose: True
 version: 0.5.0-finagle
 
 
-[gen.thrift]
-gen_options: hashcode
+[gen.thrift-java]
+gen_options_map: {'hashcode': ''}
 deps: ['3rdparty/jvm/org/apache/thrift:thrift-0.5.0']
 service_deps: ['3rdparty/jvm/org/apache/thrift:thrift-0.5.0-finagle']
 
@@ -167,7 +167,7 @@ version: 2.10
 
 [python-setup]
 # We only support commons python code running under 2.7 for now with 3.3+ support to be added later.
-interpreter_requirement: CPython>=2.7,<3
+interpreter_constraints: ['CPython>=2.7,<3']
 resolver_allow_prereleases: True
 
 

--- a/tests/java/com/twitter/common/application/BUILD
+++ b/tests/java/com/twitter/common/application/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'application',
+junit_tests(name = 'application',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/application/modules/BUILD
+++ b/tests/java/com/twitter/common/application/modules/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name='lifecycle',
+junit_tests(name='lifecycle',
   dependencies=[
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/base/BUILD
+++ b/tests/java/com/twitter/common/base/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'base',
+junit_tests(name = 'base',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/collections/BUILD
+++ b/tests/java/com/twitter/common/collections/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'collections',
+junit_tests(name = 'collections',
   dependencies = [
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/examples/pingpong/handler/BUILD
+++ b/tests/java/com/twitter/common/examples/pingpong/handler/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name='handler',
+junit_tests(name='handler',
   dependencies=[
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/inject/BUILD
+++ b/tests/java/com/twitter/common/inject/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'inject',
+junit_tests(name = 'inject',
   dependencies = [
     '3rdparty/jvm/commons-lang',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/io/BUILD
+++ b/tests/java/com/twitter/common/io/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'io',
+junit_tests(name = 'io',
   dependencies = [
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/logging/BUILD
+++ b/tests/java/com/twitter/common/logging/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'logging',
+junit_tests(name = 'logging',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/org/hamcrest:hamcrest-core',

--- a/tests/java/com/twitter/common/logging/julbridge/BUILD
+++ b/tests/java/com/twitter/common/logging/julbridge/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'julbridge',
+junit_tests(name = 'julbridge',
   dependencies = [
     '3rdparty/jvm/org/hamcrest:hamcrest-core',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/memcached/BUILD
+++ b/tests/java/com/twitter/common/memcached/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'memcached',
+junit_tests(name = 'memcached',
   dependencies = [
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/metrics/BUILD
+++ b/tests/java/com/twitter/common/metrics/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'metrics',
+junit_tests(name = 'metrics',
   dependencies = [
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/net/BUILD
+++ b/tests/java/com/twitter/common/net/BUILD
@@ -16,7 +16,7 @@
 
 
 
-java_tests(name = 'net',
+junit_tests(name = 'net',
   dependencies = [
     '3rdparty/jvm/commons-codec',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/net/http/BUILD
+++ b/tests/java/com/twitter/common/net/http/BUILD
@@ -1,4 +1,4 @@
-java_tests(name = 'http',
+junit_tests(name = 'http',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/org/mortbay/jetty',

--- a/tests/java/com/twitter/common/net/http/filters/BUILD
+++ b/tests/java/com/twitter/common/net/http/filters/BUILD
@@ -1,4 +1,4 @@
-java_tests(name = 'filters',
+junit_tests(name = 'filters',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/inject:guice',

--- a/tests/java/com/twitter/common/net/http/handlers/BUILD
+++ b/tests/java/com/twitter/common/net/http/handlers/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'handlers',
+junit_tests(name = 'handlers',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/code/gson',

--- a/tests/java/com/twitter/common/objectsize/BUILD
+++ b/tests/java/com/twitter/common/objectsize/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'objectsize',
+junit_tests(name = 'objectsize',
   dependencies = [
     '3rdparty/jvm/junit',
     'src/java/com/twitter/common/objectsize',

--- a/tests/java/com/twitter/common/quantity/BUILD
+++ b/tests/java/com/twitter/common/quantity/BUILD
@@ -16,7 +16,7 @@
 
 
 
-java_tests(name = 'quantity',
+junit_tests(name = 'quantity',
   dependencies = [
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/runtime/BUILD
+++ b/tests/java/com/twitter/common/runtime/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name='runtime',
+junit_tests(name='runtime',
   dependencies=[
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/security/unittest/BUILD
+++ b/tests/java/com/twitter/common/security/unittest/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'unittest',
+junit_tests(name = 'unittest',
   dependencies = [
     '3rdparty/jvm/junit',
 

--- a/tests/java/com/twitter/common/stats/BUILD
+++ b/tests/java/com/twitter/common/stats/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'stats',
+junit_tests(name = 'stats',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/testing/BUILD
+++ b/tests/java/com/twitter/common/testing/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name='testing',
+junit_tests(name='testing',
   dependencies=[
     '3rdparty/jvm/junit',
     '3rdparty/jvm/com/google/testing:tl4j',

--- a/tests/java/com/twitter/common/testing/easymock/BUILD
+++ b/tests/java/com/twitter/common/testing/easymock/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name='easymock',
+junit_tests(name='easymock',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/text/BUILD
+++ b/tests/java/com/twitter/common/text/BUILD
@@ -15,7 +15,7 @@
 # ==================================================================================================
 
 
-java_tests(name = 'text',
+junit_tests(name = 'text',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/thrift/BUILD
+++ b/tests/java/com/twitter/common/thrift/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name='thrift',
+junit_tests(name='thrift',
   dependencies=[
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/util/BUILD
+++ b/tests/java/com/twitter/common/util/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'util',
+junit_tests(name = 'util',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/util/caching/BUILD
+++ b/tests/java/com/twitter/common/util/caching/BUILD
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==================================================================================================
 
-java_tests(name = 'caching',
+junit_tests(name = 'caching',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/util/concurrent/BUILD
+++ b/tests/java/com/twitter/common/util/concurrent/BUILD
@@ -1,4 +1,4 @@
-java_tests(name = 'concurrent',
+junit_tests(name = 'concurrent',
   dependencies = [
     '3rdparty/jvm/junit',
     'src/java/com/twitter/common/testing/easymock',

--- a/tests/java/com/twitter/common/util/templating/BUILD
+++ b/tests/java/com/twitter/common/util/templating/BUILD
@@ -1,4 +1,4 @@
-java_tests(name='templating',
+junit_tests(name='templating',
   dependencies=[
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/junit',

--- a/tests/java/com/twitter/common/zookeeper/BUILD
+++ b/tests/java/com/twitter/common/zookeeper/BUILD
@@ -33,7 +33,7 @@ LARGE = [
   'ZooKeeperNodeTest.java',
 ]
 
-java_tests(name = 'small',
+junit_tests(name = 'small',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',
@@ -48,7 +48,7 @@ java_tests(name = 'small',
   sources = globs('*.java', exclude=[MEDIUM, LARGE])
 )
 
-java_tests(name = 'medium-main',
+junit_tests(name = 'medium-main',
   dependencies = [
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/com/google/inject:guice',
@@ -75,7 +75,7 @@ target(name = 'medium',
   ]
 )
 
-java_tests(name = 'large',
+junit_tests(name = 'large',
   dependencies = [
     '3rdparty/jvm/org/easymock',
     '3rdparty/jvm/com/google/guava',

--- a/tests/java/com/twitter/common/zookeeper/testing/angrybird/BUILD
+++ b/tests/java/com/twitter/common/zookeeper/testing/angrybird/BUILD
@@ -1,4 +1,4 @@
-java_tests(name = 'angrybird',
+junit_tests(name = 'angrybird',
   dependencies = [
     '3rdparty/jvm/com/google/guava',
     '3rdparty/jvm/org/hamcrest:hamcrest-core',


### PR DESCRIPTION
### Problem

The 1.2.1 upgrade was incomplete, and didn't update the ci.sh script for python.

### Solution

Bump to a newer version, allow prerelease python dependencies, raise the python version constraint, and remove deprecated flags.
