### PR TITLE
Add option to sort commands names in python app help

### DIFF
--- a/README
+++ b/README
@@ -15,7 +15,7 @@ $ ./pants test {src,tests}/java/com/twitter/common::
 $ ./pants test {src,tests}/scala/com/twitter/common::
 
 Likewise for python commons:
-$ ./pants test tests/python/twitter/common/:all
+$ ./pants test tests/python/twitter/common::
 
 To get help on pants:
 $ ./pants help

--- a/src/python/twitter/common/app/application.py
+++ b/src/python/twitter/common/app/application.py
@@ -634,10 +634,9 @@ class Application(object):
     """
       Sets the usage message automatically, to show the available commands.
     """
+    commands_and_docstrings = self.get_commands_and_docstrings()
     if sort:
-      commands_and_docstrings = sorted(self.get_commands_and_docstrings())
-    else:
-      commands_and_docstrings = self.get_commands_and_docstrings()
+      commands_and_docstrings = sorted(commands_and_docstrings)
     self.set_usage(
       'Please run with one of the following commands:\n' +
       '\n'.join(['  %-22s%s' % (command, self._set_string_margin(docstring or '', 0, 24))

--- a/src/python/twitter/common/app/application.py
+++ b/src/python/twitter/common/app/application.py
@@ -630,14 +630,18 @@ class Application(object):
     """
     self._usage = usage
 
-  def set_usage_based_on_commands(self):
+  def set_usage_based_on_commands(self, sort=False):
     """
       Sets the usage message automatically, to show the available commands.
     """
+    if sort:
+      commands_and_docstrings = sorted(self.get_commands_and_docstrings())
+    else:
+      commands_and_docstrings = self.get_commands_and_docstrings()
     self.set_usage(
       'Please run with one of the following commands:\n' +
       '\n'.join(['  %-22s%s' % (command, self._set_string_margin(docstring or '', 0, 24))
-                 for (command, docstring) in self.get_commands_and_docstrings()])
+                 for (command, docstring) in commands_and_docstrings])
     )
 
   @staticmethod

--- a/tests/python/twitter/common/app/test_app.py
+++ b/tests/python/twitter/common/app/test_app.py
@@ -389,3 +389,53 @@ def test_shutdown_exception():
   app.register_shutdown_command(shutdown_command)
   app.main()
   assert app.exited_rc == 0
+
+
+def test_application_help():
+  def real_main():
+    return 0
+
+  def make_app_with_commands(*args):
+    app = TestApplication(*args)
+
+    @app.command
+    def help():
+      return "help"
+
+    @app.command
+    def a_command():
+      return 1
+
+    @app.command
+    def z_command():
+      return 1
+
+    @app.command
+    def command_one():
+      return 1
+
+    @app.command
+    def command_two():
+      return 2
+
+    @app.command
+    def command_three():
+      return 3
+
+    return app
+
+  app = make_app_with_commands(real_main)
+  sorted_commands = (
+    'a_command',
+    'command_one',
+    'command_three',
+    'command_two',
+    'help',
+    'z_command')
+  help_msg = 'Please run with one of the following commands:\n' + \
+    '\n'.join(['  %-22s' % command for command in sorted_commands])
+
+  app.set_usage_based_on_commands()
+  assert(not app._usage == help_msg)
+  app.set_usage_based_on_commands(sort=True)
+  assert(app._usage == help_msg)


### PR DESCRIPTION
Allow sorting of command names for help in python apps

### Problem

When automatically generating help from the list of commands in a python app the commands will appear in an arbitrary order.  This can make the output, when there are a numerous commands, confusing.

### Solution

Add an option to sort the list of commands when generating the help output.
Also add tests and a small fix to the readme.

### Result

Developers can easily ensure a sorted list of commands will be printed when users call the app help.
