### PR TITLE
fixed issue #329

### DIFF
--- a/src/python/twitter/common/dirutil/lock.py
+++ b/src/python/twitter/common/dirutil/lock.py
@@ -45,10 +45,10 @@ class Lock(object):
     lock_fd = lock_file(path, blocking=False)
     if not lock_fd:
       blocking = True
-      with open(path, 'r') as fd:
-        pid = int(fd.read().strip())
-        if onwait:
-          blocking = onwait(pid)
+      if onwait:
+          with open(path, 'r') as fd:
+              pid = int(fd.read().strip())
+              blocking = onwait(pid)
       if not blocking:
         return None
       lock_fd = lock_file(path, blocking=blocking)


### PR DESCRIPTION
### Problem

This fixes issue #329 , where one process was reading a file partially written by another process.

### Solution

Only open the file once the 'if onwait' is true. This is done by moving the file read operation within the if statement.
