### PR TITLE
Make concurrent.deadline compatible with Python 3

### DIFF
--- a/src/python/twitter/common/concurrent/deadline.py
+++ b/src/python/twitter/common/concurrent/deadline.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 # ==================================================================================================
 
-from Queue import Queue, Empty
+try:
+  from Queue import Queue, Empty
+except ImportError:
+  from queue import Queue, Empty
+
 from threading import Thread
 
-from twitter.common.exceptions import ExceptionalThread
 from twitter.common.lang import Compatibility
 from twitter.common.quantity import Amount, Time
 

--- a/src/python/twitter/common/concurrent/deadline.py
+++ b/src/python/twitter/common/concurrent/deadline.py
@@ -56,10 +56,12 @@ def deadline(closure, timeout=Amount(150, Time.MILLISECONDS), daemon=False, prop
     def run(self):
       try:
         result = closure()
-      except Exception as result:
-        if not propagate:
+      except Exception as e:
+        if propagate:
+          result = e
+        else:
           # conform to standard behaviour of an exception being raised inside a Thread
-          raise result
+          raise e
       q.put(result)
   AnonymousThread().start()
   try:

--- a/src/python/twitter/common/concurrent/event_muxer.py
+++ b/src/python/twitter/common/concurrent/event_muxer.py
@@ -14,7 +14,11 @@
 # limitations under the License.
 # ==================================================================================================
 
-from Queue import Empty, Queue
+try:
+  from Queue import Queue, Empty
+except ImportError:
+  from queue import Queue, Empty
+
 import threading
 
 class EventMuxer(object):

--- a/tests/python/twitter/common/concurrent/test_concurrent.py
+++ b/tests/python/twitter/common/concurrent/test_concurrent.py
@@ -1,6 +1,9 @@
 import time
 from functools import partial
-from Queue import Empty, Queue
+try:
+  from Queue import Queue
+except ImportError:
+  from queue import Queue
 
 import pytest
 from twitter.common.concurrent import deadline, defer, Timeout

--- a/tests/python/twitter/common/exceptions/test_exceptions.py
+++ b/tests/python/twitter/common/exceptions/test_exceptions.py
@@ -18,7 +18,10 @@ import sys
 import threading
 from collections import namedtuple
 from contextlib import contextmanager
-from Queue import Queue
+try:
+  from Queue import Queue
+except ImportError:
+  from queue import Queue
 
 from twitter.common.exceptions import ExceptionalThread
 


### PR DESCRIPTION
### Problem

`twitter.common.concurrent` cannot be imported with Python 3 due to the rename of `Queue` to `queue`. Additionally, the current exception handling code is incompatible with Python 3 scoping changes.

### Solution
A few of imports in this repo have already been fixed to fail gracefully.  Adopt the same workaround for all usages of `Queue`


### Result
The following code runs with Python 3.6 as expected:
```python
from twitter.common.concurrent import deadline

def myfunctor_happy():
    return "I am running deferred"

def myfunctor_unhappy():
    raise Exception("I am failing deferred")

print(deadline(myfunctor_happy, propagate=True))
print(deadline(myfunctor_unhappy, propagate=True))
```