### PR TITLE
Switch To Travis To VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-# Enables support for a docker container-based build
-# which should provide faster startup times and beefier
-# "machines". This is also required in order to use the
-# cache configured below.
-sudo: false
-
 before_cache:
     # The `ivydata-*.properties` & root level `*.{properties,xml}` files'
     # effect on resolution time is in the noise, but they are
@@ -31,4 +25,3 @@ jdk:
 script: |
   java -version
   ./build-support/bin/ci.sh
-


### PR DESCRIPTION
Problem
- Travis is moving away from container based builds (see: [deprecation notice](https://changelog.travis-ci.com/deprecation-container-based-linux-build-environment-82037) and [blog post](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration))

Solution
- Move to VM before they make the switch mandatory

Result
- No changes to build output

