### PR TITLE
Fix collections.abc deprecation

### DIFF
--- a/src/python/twitter/common/collections/orderedset.py
+++ b/src/python/twitter/common/collections/orderedset.py
@@ -20,10 +20,13 @@
 # modifications
 #
 
-import collections
+try:
+  # Python 3 moved MutableSet to collections.abc
+  from collections.abc import MutableSet
+except ImportError:
+  from collections import MutableSet
 
-
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
   KEY, PREV, NEXT = range(3)
 
   def __init__(self, iterable=None):


### PR DESCRIPTION
### Problem
In Python 3, the collections type classes (e.g. `MutableMapping`, `Iterable`) were moved to `collections.abc`. They were kept in `collections` for backwards compatibility, but will be removed in Python 3.8 and cause a deprecation warning in Python 3.7.

This leads to deprecation warnings for any Commons consumers, such as Pants.

### Solution
Try to import `collections.abc`, and fall back to `collections`. 

This fallback will be necessary until Commons would ever decide to drop Python 2 support, if that ever would even happen.
