### PR TITLE
Fix invalid escape sequence DeprecationWarning

### DIFF
--- a/src/python/twitter/common/dirutil/fileset.py
+++ b/src/python/twitter/common/dirutil/fileset.py
@@ -67,7 +67,7 @@ def fnmatch_translate_extended(pat):
         res += '[' + stuff + ']'
     else:
       res += re.escape(c)
-  return res + '\Z(?ms)'
+  return res + r'\Z(?ms)'
 
 
 class Fileset(object):


### PR DESCRIPTION
This is leading to a DeprecationWarning when running Pants with Python 3 (https://travis-ci.org/pantsbuild/pants/jobs/481546379#L456).